### PR TITLE
Std osc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +1842,7 @@ dependencies = [
  "libmath",
  "midir",
  "num 0.2.1",
+ "parking_lot 0.11.0",
  "pitch_calc",
  "rand 0.7.3",
  "rand_distr",
@@ -1860,7 +1879,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -1871,8 +1890,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -1882,7 +1912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -1897,7 +1927,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.1",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec 1.4.1",
@@ -2165,7 +2210,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
@@ -2302,7 +2347,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -2740,7 +2785,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd0a4829a5c591dc24a944a736d6b1e4053e51339a79fd5d4702c4c999a9c45e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
 ]
 
 [[package]]

--- a/nannou-apps/src/bin/demo.rs
+++ b/nannou-apps/src/bin/demo.rs
@@ -4,7 +4,7 @@ use nannou_audio as audio;
 use nannou_audio::Buffer;
 use oscen::filters::Lpf;
 use oscen::operators::Modulator;
-use oscen::oscillators::{sine_osc, square_osc, StdOsc};
+use oscen::oscillators::{sine_osc, square_osc, Oscillator};
 use oscen::signal::*;
 
 fn main() {
@@ -35,7 +35,7 @@ fn model(app: &App) -> Model {
 
     // Create a square wave oscillator and add it the the rack.
     // let square = SquareOsc::new().hz(modulator.tag()).rack(&mut rack);
-    let square = StdOsc::new(square_osc)
+    let square = Oscillator::new(square_osc)
         .hz(modulator.tag())
         .arg(0.5)
         .rack(&mut rack);

--- a/nannou-apps/src/bin/demo.rs
+++ b/nannou-apps/src/bin/demo.rs
@@ -4,7 +4,7 @@ use nannou_audio as audio;
 use nannou_audio::Buffer;
 use oscen::filters::Lpf;
 use oscen::operators::Modulator;
-use oscen::oscillators::{SineOsc, SquareOsc};
+use oscen::oscillators::{StdOsc, sine_osc, square_osc};
 use oscen::signal::*;
 
 fn main() {
@@ -32,18 +32,22 @@ fn model(app: &App) -> Model {
     let mut rack = Rack::new(vec![]);
 
     // Use a low frequencey sine wave to modulate the frequency of a square wave.
-    let sine = SineOsc::new().hz(1).rack(&mut rack);
+    let sine = StdOsc::new(sine_osc).hz(1760).rack(&mut rack);
+    // let sine = SineOsc::new().hz(1760).rack(&mut rack);
     let modulator = Modulator::new(sine.tag())
-        .base_hz(440)
-        .mod_hz(220)
-        .mod_idx(1)
+        .hz(440)
+        .ratio(4)
+        .index(2)
         .rack(&mut rack);
 
     // Create a square wave oscillator and add it the the rack.
-    let square = SquareOsc::new().hz(modulator.tag()).rack(&mut rack);
+    // let square = SquareOsc::new().hz(modulator.tag()).rack(&mut rack);
+    let square = StdOsc::new(square_osc).hz(modulator.tag()).arg(0.5).rack(&mut rack);
+
+
 
     // Create a low pass filter whose input is the square wave.
-    Lpf::new(square.tag()).cutoff_freq(880).rack(&mut rack);
+    Lpf::new(square.tag()).cutoff_freq(440).rack(&mut rack);
 
     let synth = Synth { sender, rack };
     let stream = audio_host

--- a/nannou-apps/src/bin/demo.rs
+++ b/nannou-apps/src/bin/demo.rs
@@ -31,7 +31,7 @@ fn model(app: &App) -> Model {
     // A Rack is a collection of synth modules.
     let mut rack = Rack::new(vec![]);
 
-    let modulator = Modulator::new(sine_osc, 440.into(), 4.into(), 2.into()).rack(&mut rack);
+    let modulator = Modulator::new(sine_osc, 440, 4, 2).rack(&mut rack);
 
     // Create a square wave oscillator and add it the the rack.
     // let square = SquareOsc::new().hz(modulator.tag()).rack(&mut rack);

--- a/nannou-apps/src/bin/demo.rs
+++ b/nannou-apps/src/bin/demo.rs
@@ -4,7 +4,7 @@ use nannou_audio as audio;
 use nannou_audio::Buffer;
 use oscen::filters::Lpf;
 use oscen::operators::Modulator;
-use oscen::oscillators::{StdOsc, sine_osc, square_osc};
+use oscen::oscillators::{sine_osc, square_osc, StdOsc};
 use oscen::signal::*;
 
 fn main() {
@@ -31,20 +31,14 @@ fn model(app: &App) -> Model {
     // A Rack is a collection of synth modules.
     let mut rack = Rack::new(vec![]);
 
-    // Use a low frequencey sine wave to modulate the frequency of a square wave.
-    let sine = StdOsc::new(sine_osc).hz(1760).rack(&mut rack);
-    // let sine = SineOsc::new().hz(1760).rack(&mut rack);
-    let modulator = Modulator::new(sine.tag())
-        .hz(440)
-        .ratio(4)
-        .index(2)
-        .rack(&mut rack);
+    let modulator = Modulator::new(sine_osc, 440.into(), 4.into(), 2.into()).rack(&mut rack);
 
     // Create a square wave oscillator and add it the the rack.
     // let square = SquareOsc::new().hz(modulator.tag()).rack(&mut rack);
-    let square = StdOsc::new(square_osc).hz(modulator.tag()).arg(0.5).rack(&mut rack);
-
-
+    let square = StdOsc::new(square_osc)
+        .hz(modulator.tag())
+        .arg(0.5)
+        .rack(&mut rack);
 
     // Create a low pass filter whose input is the square wave.
     Lpf::new(square.tag()).cutoff_freq(440).rack(&mut rack);

--- a/nannou-apps/src/bin/perf.rs
+++ b/nannou-apps/src/bin/perf.rs
@@ -1,7 +1,7 @@
 use nannou::prelude::*;
 use nannou_audio as audio;
 use nannou_audio::Buffer;
-use oscen::oscillators::{sine_osc, Oscillator};
+use oscen::oscillators::*;
 use oscen::operators::Mixer;
 use oscen::signal::*;
 
@@ -17,17 +17,18 @@ fn model(app: &App) -> Model {
     app.new_window().size(250, 250).build().unwrap();
     let audio_host = audio::Host::new();
     let mut rack = Rack::new(vec![]);
-    let num_oscillators = 120;
+    let num_oscillators = 100;
     let amp = 1.0 / num_oscillators as f64;
     let mut oscs = vec![];
     for _ in 0..num_oscillators {
-        let osc = Oscillator::new(sine_osc)
+        let osc = Oscillator::new(square_osc)
             .amplitude(amp)
             .hz(200)
+            .arg(0.5)
             .rack(&mut rack);
         oscs.push(osc.tag());
     }
-    Mixer::new(oscs).rack(&mut rack);
+    Mixer::new(oscs).level(0.2).rack(&mut rack);
     let stream = audio_host
         .new_output_stream(rack)
         .render(audio)

--- a/nannou-apps/src/bin/perf.rs
+++ b/nannou-apps/src/bin/perf.rs
@@ -1,0 +1,47 @@
+use nannou::prelude::*;
+use nannou_audio as audio;
+use nannou_audio::Buffer;
+use oscen::oscillators::{sine_osc, Oscillator};
+use oscen::operators::Mixer;
+use oscen::signal::*;
+
+fn main() {
+    nannou::app(model).run();
+}
+
+struct Model {
+    stream: audio::Stream<Rack>,
+}
+
+fn model(app: &App) -> Model {
+    app.new_window().size(250, 250).build().unwrap();
+    let audio_host = audio::Host::new();
+    let mut rack = Rack::new(vec![]);
+    let num_oscillators = 120;
+    let amp = 1.0 / num_oscillators as f64;
+    let mut oscs = vec![];
+    for _ in 0..num_oscillators {
+        let osc = Oscillator::new(sine_osc)
+            .amplitude(amp)
+            .hz(200)
+            .rack(&mut rack);
+        oscs.push(osc.tag());
+    }
+    Mixer::new(oscs).rack(&mut rack);
+    let stream = audio_host
+        .new_output_stream(rack)
+        .render(audio)
+        .build()
+        .unwrap();
+    Model { stream }
+}
+
+fn audio(rack: &mut Rack, buffer: &mut Buffer) {
+    let sample_rate = buffer.sample_rate() as Real;
+    for frame in buffer.frames_mut() {
+        let amp = rack.signal(sample_rate) as f32;
+        for channel in frame {
+            *channel = amp;
+        }
+    }
+}

--- a/nannou-apps/src/bin/pluck.rs
+++ b/nannou-apps/src/bin/pluck.rs
@@ -5,7 +5,7 @@ use nannou_audio::Buffer;
 use std::thread;
 use oscen::instruments::WaveGuide;
 use oscen::midi::{listen_midi, MidiControl, MidiPitch};
-use oscen::oscillators::SquareOsc;
+use oscen::oscillators::{StdOsc, square_osc};
 use oscen::signal::{ArcMutex, Builder, Rack, Real, Signal, Tag, Gate};
 
 fn main() {
@@ -41,7 +41,7 @@ fn build_synth(midi_receiver: Receiver<Vec<u8>>, sender: Sender<f32>) -> Synth {
     let midi_pitch = MidiPitch::new().rack(&mut rack);
     MidiControl::new(1, 64, 0.0, 0.5, 1.0).rack(&mut rack);
 
-    let excite = SquareOsc::new().hz(110).rack(&mut rack);
+    let excite = StdOsc::new(square_osc).hz(110).rack(&mut rack);
 
     let karplus = WaveGuide::new(excite.tag())
         .hz(midi_pitch.tag())

--- a/nannou-apps/src/bin/pluck.rs
+++ b/nannou-apps/src/bin/pluck.rs
@@ -5,7 +5,7 @@ use nannou_audio::Buffer;
 use std::thread;
 use oscen::instruments::WaveGuide;
 use oscen::midi::{listen_midi, MidiControl, MidiPitch};
-use oscen::oscillators::{StdOsc, square_osc};
+use oscen::oscillators::{Oscillator, square_osc};
 use oscen::signal::{ArcMutex, Builder, Rack, Real, Signal, Tag, Gate};
 
 fn main() {
@@ -41,7 +41,7 @@ fn build_synth(midi_receiver: Receiver<Vec<u8>>, sender: Sender<f32>) -> Synth {
     let midi_pitch = MidiPitch::new().rack(&mut rack);
     MidiControl::new(1, 64, 0.0, 0.5, 1.0).rack(&mut rack);
 
-    let excite = StdOsc::new(square_osc).hz(110).rack(&mut rack);
+    let excite = Oscillator::new(square_osc).hz(110).rack(&mut rack);
 
     let karplus = WaveGuide::new(excite.tag())
         .hz(midi_pitch.tag())

--- a/nannou-apps/src/bin/pluck.rs
+++ b/nannou-apps/src/bin/pluck.rs
@@ -98,7 +98,7 @@ fn audio(synth: &mut Synth, buffer: &mut Buffer) {
         if message.len() == 3 {
             let step = message[1] as f32;
             if message[0] == 144 {
-                synth.midi.midi_pitch.lock().unwrap().step(step);
+                synth.midi.midi_pitch.lock().step(step);
                 WaveGuide::gate_on(&synth.rack, karplus_tag);
             } else if message[0] == 128 {
                 WaveGuide::gate_off(&synth.rack, karplus_tag);

--- a/nannou-apps/src/bin/seq.rs
+++ b/nannou-apps/src/bin/seq.rs
@@ -49,7 +49,7 @@ fn build_synth(sender: Sender<f32>) -> Synth {
 
     let gate_seq = GateSeq::new(seq).rack(&mut rack);
 
-    let wave = SawOsc::new().hz(pitch_seq.tag()).rack(&mut rack);
+    let wave = StdOsc::new(saw_osc).hz(pitch_seq.tag()).rack(&mut rack);
 
     let lpf = Lpf::new(wave.tag()).cutoff_freq(400).rack(&mut rack);
 

--- a/nannou-apps/src/bin/seq.rs
+++ b/nannou-apps/src/bin/seq.rs
@@ -49,7 +49,7 @@ fn build_synth(sender: Sender<f32>) -> Synth {
 
     let gate_seq = GateSeq::new(seq).rack(&mut rack);
 
-    let wave = StdOsc::new(saw_osc).hz(pitch_seq.tag()).rack(&mut rack);
+    let wave = Oscillator::new(saw_osc).hz(pitch_seq.tag()).rack(&mut rack);
 
     let lpf = Lpf::new(wave.tag()).cutoff_freq(400).rack(&mut rack);
 

--- a/nannou-apps/src/bin/sv1.rs
+++ b/nannou-apps/src/bin/sv1.rs
@@ -7,7 +7,7 @@ use oscen::envelopes::Adsr;
 use oscen::filters::Lpf;
 use oscen::midi::{listen_midi, MidiControl, MidiPitch};
 use oscen::operators::{Mixer, Modulator, Vca};
-use oscen::oscillators::{saw_osc, sine_osc, square_osc, triangle_osc, StdOsc, WhiteNoise};
+use oscen::oscillators::{saw_osc, sine_osc, square_osc, triangle_osc, Oscillator, WhiteNoise};
 use oscen::signal::{ArcMutex, Builder, Gate, Rack, Real, Signal, Tag};
 use std::thread;
 
@@ -65,10 +65,10 @@ fn build_synth(
     midi_controls.push(midi_control_tri_lfo_hz.clone());
 
     // LFO's
-    let tri_lfo = StdOsc::new(triangle_osc)
+    let tri_lfo = Oscillator::new(triangle_osc)
         .hz(midi_control_tri_lfo_hz.tag())
         .rack(&mut rack);
-    StdOsc::new(square_osc).rack(&mut rack);
+    Oscillator::new(square_osc).rack(&mut rack);
 
     let midi_control_mod_hz2 = MidiControl::new(44, 0, 0.0, 440.0, 1760.0).rack_pre(&mut rack);
     midi_controls.push(midi_control_mod_hz2.clone());
@@ -86,12 +86,12 @@ fn build_synth(
     .rack(&mut rack);
 
     // Oscillator 2
-    let sine2 = StdOsc::new(sine_osc)
+    let sine2 = Oscillator::new(sine_osc)
         .hz(modulator_osc2.tag())
         .rack(&mut rack);
-    StdOsc::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
-    StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
-    StdOsc::new(triangle_osc)
+    Oscillator::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    Oscillator::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    Oscillator::new(triangle_osc)
         .hz(midi_pitch.tag())
         .rack(&mut rack);
 
@@ -112,21 +112,21 @@ fn build_synth(
     let midi_control_pulse_width = MidiControl::new(39, 0, 0.05, 0.5, 0.95).rack_pre(&mut rack);
     midi_controls.push(midi_control_pulse_width.clone());
 
-    let sine1 = StdOsc::new(sine_osc)
+    let sine1 = Oscillator::new(sine_osc)
         .hz(modulator_osc1.tag())
         .rack(&mut rack);
-    let saw1 = StdOsc::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
-    let square1 = StdOsc::new(square_osc)
+    let saw1 = Oscillator::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    let square1 = Oscillator::new(square_osc)
         .hz(midi_pitch.tag())
         .arg(midi_control_pulse_width.tag())
         .rack(&mut rack);
-    let triangle1 = StdOsc::new(triangle_osc)
+    let triangle1 = Oscillator::new(triangle_osc)
         .hz(midi_pitch.tag())
         .rack(&mut rack);
 
     // Sub 1 & 2
-    StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
-    StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    Oscillator::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    Oscillator::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
 
     // Noise
     let noise = WhiteNoise::new().rack(&mut rack);

--- a/nannou-apps/src/bin/sv1.rs
+++ b/nannou-apps/src/bin/sv1.rs
@@ -246,13 +246,13 @@ fn audio(synth: &mut Synth, buffer: &mut Buffer) {
         if message.len() == 3 {
             let midi_step = message[1] as f32;
             if message[0] == 144 {
-                synth.midi.midi_pitch.lock().unwrap().step(midi_step);
+                synth.midi.midi_pitch.lock().step(midi_step);
                 Adsr::gate_on(&synth.voice, adsr_tag);
             } else if message[0] == 128 {
                 Adsr::gate_off(&synth.voice, adsr_tag);
             } else if message[0] == 176 {
                 for c in &synth.midi.midi_controls {
-                    let mut control = c.lock().unwrap();
+                    let mut control = c.lock();
                     if control.controller == message[1] {
                         control.value(message[2]);
                     }

--- a/nannou-apps/src/bin/sv1.rs
+++ b/nannou-apps/src/bin/sv1.rs
@@ -8,7 +8,7 @@ use oscen::envelopes::Adsr;
 use oscen::filters::Lpf;
 use oscen::midi::{listen_midi, MidiControl, MidiPitch};
 use oscen::operators::{Mixer, Modulator, Vca};
-use oscen::oscillators::{SawOsc, SineOsc, SquareOsc, TriangleOsc, WhiteNoise};
+use oscen::oscillators::{StdOsc, sine_osc, square_osc, triangle_osc, saw_osc, WhiteNoise};
 use oscen::signal::{ArcMutex, Builder, Gate, Rack, Real, Signal, Tag};
 
 fn main() {
@@ -65,10 +65,10 @@ fn build_synth(
     midi_controls.push(midi_control_tri_lfo_hz.clone());
 
     // LFO's
-    let tri_lfo = TriangleOsc::new()
+    let tri_lfo = StdOsc::new(triangle_osc)
         .hz(midi_control_tri_lfo_hz.tag())
         .rack(&mut rack);
-    SquareOsc::new().rack(&mut rack);
+    StdOsc::new(square_osc).rack(&mut rack);
 
     let midi_control_mod_hz2 = MidiControl::new(44, 0, 0.0, 440.0, 1760.0).rack_pre(&mut rack);
     midi_controls.push(midi_control_mod_hz2.clone());
@@ -78,16 +78,16 @@ fn build_synth(
     // TODO: tune these lower
     // Sub Oscillators for Osc
     let modulator_osc2 = Modulator::new(tri_lfo.tag().into())
-        .base_hz(midi_pitch.tag())
-        .mod_hz(midi_control_mod_hz2.tag())
-        .mod_idx(midi_control_mod_idx2.tag())
+        .hz(midi_pitch.tag())
+        .ratio(midi_control_mod_hz2.tag())
+        .index(midi_control_mod_idx2.tag())
         .rack(&mut rack);
 
     // Oscillator 2
-    let sine2 = SineOsc::new().hz(modulator_osc2.tag()).rack(&mut rack);
-    SawOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
-    SquareOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
-    TriangleOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
+    let sine2 = StdOsc::new(sine_osc).hz(modulator_osc2.tag()).rack(&mut rack);
+    StdOsc::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    StdOsc::new(triangle_osc).hz(midi_pitch.tag()).rack(&mut rack);
 
     let midi_control_mod_hz1 = MidiControl::new(43, 0, 0.0, 440.0, 1760.0).rack_pre(&mut rack);
     midi_controls.push(midi_control_mod_hz1.clone());
@@ -95,26 +95,26 @@ fn build_synth(
     midi_controls.push(midi_control_mod_idx1.clone());
 
     let modulator_osc1 = Modulator::new(sine2.tag())
-        .base_hz(midi_pitch.tag())
-        .mod_hz(midi_control_mod_hz1.tag())
-        .mod_idx(midi_control_mod_idx1.tag())
+        .hz(midi_pitch.tag())
+        .ratio(midi_control_mod_hz1.tag())
+        .index(midi_control_mod_idx1.tag())
         .rack(&mut rack);
 
     // Oscillator 1
     let midi_control_pulse_width = MidiControl::new(39, 0, 0.05, 0.5, 0.95).rack_pre(&mut rack);
     midi_controls.push(midi_control_pulse_width.clone());
 
-    let sine1 = SineOsc::new().hz(modulator_osc1.tag()).rack(&mut rack);
-    let saw1 = SawOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
-    let square1 = SquareOsc::new()
+    let sine1 = StdOsc::new(sine_osc).hz(modulator_osc1.tag()).rack(&mut rack);
+    let saw1 = StdOsc::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    let square1 = StdOsc::new(square_osc)
         .hz(midi_pitch.tag())
-        .duty_cycle(midi_control_pulse_width.tag())
+        .arg(midi_control_pulse_width.tag())
         .rack(&mut rack);
-    let triangle1 = TriangleOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
+    let triangle1 = StdOsc::new(triangle_osc).hz(midi_pitch.tag()).rack(&mut rack);
 
     // Sub 1 & 2
-    SquareOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
-    SquareOsc::new().hz(midi_pitch.tag()).rack(&mut rack);
+    StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
 
     // Noise
     let noise = WhiteNoise::new().rack(&mut rack);

--- a/nannou-apps/src/bin/sv1.rs
+++ b/nannou-apps/src/bin/sv1.rs
@@ -3,13 +3,13 @@ use crossbeam::crossbeam_channel::{unbounded, Receiver, Sender};
 use nannou::prelude::*;
 use nannou_audio as audio;
 use nannou_audio::Buffer;
-use std::thread;
 use oscen::envelopes::Adsr;
 use oscen::filters::Lpf;
 use oscen::midi::{listen_midi, MidiControl, MidiPitch};
 use oscen::operators::{Mixer, Modulator, Vca};
-use oscen::oscillators::{StdOsc, sine_osc, square_osc, triangle_osc, saw_osc, WhiteNoise};
+use oscen::oscillators::{saw_osc, sine_osc, square_osc, triangle_osc, StdOsc, WhiteNoise};
 use oscen::signal::{ArcMutex, Builder, Gate, Rack, Real, Signal, Tag};
+use std::thread;
 
 fn main() {
     nannou::app(model).update(update).run();
@@ -77,40 +77,52 @@ fn build_synth(
 
     // TODO: tune these lower
     // Sub Oscillators for Osc
-    let modulator_osc2 = Modulator::new(tri_lfo.tag().into())
-        .hz(midi_pitch.tag())
-        .ratio(midi_control_mod_hz2.tag())
-        .index(midi_control_mod_idx2.tag())
-        .rack(&mut rack);
+    let modulator_osc2 = Modulator::new(
+        triangle_osc,
+        midi_pitch.tag(),
+        midi_control_mod_hz2.tag(),
+        midi_control_mod_idx2.tag(),
+    )
+    .rack(&mut rack);
 
     // Oscillator 2
-    let sine2 = StdOsc::new(sine_osc).hz(modulator_osc2.tag()).rack(&mut rack);
+    let sine2 = StdOsc::new(sine_osc)
+        .hz(modulator_osc2.tag())
+        .rack(&mut rack);
     StdOsc::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
     StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);
-    StdOsc::new(triangle_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    StdOsc::new(triangle_osc)
+        .hz(midi_pitch.tag())
+        .rack(&mut rack);
 
     let midi_control_mod_hz1 = MidiControl::new(43, 0, 0.0, 440.0, 1760.0).rack_pre(&mut rack);
     midi_controls.push(midi_control_mod_hz1.clone());
     let midi_control_mod_idx1 = MidiControl::new(42, 0, 0.0, 4.0, 16.0).rack_pre(&mut rack);
     midi_controls.push(midi_control_mod_idx1.clone());
 
-    let modulator_osc1 = Modulator::new(sine2.tag())
-        .hz(midi_pitch.tag())
-        .ratio(midi_control_mod_hz1.tag())
-        .index(midi_control_mod_idx1.tag())
-        .rack(&mut rack);
+    let modulator_osc1 = Modulator::new(
+        sine_osc,
+        midi_pitch.tag(),
+        midi_control_mod_hz1.tag(),
+        midi_control_mod_idx1.tag(),
+    )
+    .rack(&mut rack);
 
     // Oscillator 1
     let midi_control_pulse_width = MidiControl::new(39, 0, 0.05, 0.5, 0.95).rack_pre(&mut rack);
     midi_controls.push(midi_control_pulse_width.clone());
 
-    let sine1 = StdOsc::new(sine_osc).hz(modulator_osc1.tag()).rack(&mut rack);
+    let sine1 = StdOsc::new(sine_osc)
+        .hz(modulator_osc1.tag())
+        .rack(&mut rack);
     let saw1 = StdOsc::new(saw_osc).hz(midi_pitch.tag()).rack(&mut rack);
     let square1 = StdOsc::new(square_osc)
         .hz(midi_pitch.tag())
         .arg(midi_control_pulse_width.tag())
         .rack(&mut rack);
-    let triangle1 = StdOsc::new(triangle_osc).hz(midi_pitch.tag()).rack(&mut rack);
+    let triangle1 = StdOsc::new(triangle_osc)
+        .hz(midi_pitch.tag())
+        .rack(&mut rack);
 
     // Sub 1 & 2
     StdOsc::new(square_osc).hz(midi_pitch.tag()).rack(&mut rack);

--- a/oscen-lib/Cargo.toml
+++ b/oscen-lib/Cargo.toml
@@ -25,3 +25,4 @@ rand_distr = "0.2"
 uuid = {version = "0.8.1", features = ["v4"]}
 libmath = "0.2.1"
 crossbeam = "0.7"
+parking_lot = "0.11"

--- a/oscen-lib/README.md
+++ b/oscen-lib/README.md
@@ -1,6 +1,6 @@
 # Oscen [![crates.io](https://img.shields.io/crates/v/oscen.svg)](https://crates.io/crates/oscen)
 
-Oscen _[“oh-sin”]_ is a library for building modular synthesizers in Rust.
+Oscen [“oh-sin”] is a library for building modular synthesizers in Rust.
 
 It contains a collection of components frequently used in sound synthesis
 such as oscillators, filters, and envelope generators. It lets you
@@ -15,7 +15,7 @@ use nannou_audio as audio;
 use nannou_audio::Buffer;
 use oscen::filters::Lpf;
 use oscen::operators::Modulator;
-use oscen::oscillators::{SineOsc, SquareOsc};
+use oscen::oscillators::{sine_osc, square_osc, Oscillator};
 use oscen::signal::*;
 
 fn main() {
@@ -42,19 +42,16 @@ fn model(app: &App) -> Model {
     // A Rack is a collection of synth modules.
     let mut rack = Rack::new(vec![]);
 
-    // Use a low frequencey sine wave to modulate the frequency of a square wave.
-    let sine = SineOsc::new().hz(1).rack(&mut rack);
-    let modulator = Modulator::new(sine.tag())
-        .base_hz(440)
-        .mod_hz(220)
-        .mod_idx(1)
-        .rack(&mut rack);
+    let modulator = Modulator::new(sine_osc, 440, 4, 2).rack(&mut rack);
 
     // Create a square wave oscillator and add it the the rack.
-    let square = SquareOsc::new().hz(modulator.tag()).rack(&mut rack);
+    let square = Oscillator::new(square_osc)
+        .hz(modulator.tag())
+        .arg(0.5)
+        .rack(&mut rack);
 
     // Create a low pass filter whose input is the square wave.
-    Lpf::new(square.tag()).cutoff_freq(880).rack(&mut rack);
+    Lpf::new(square.tag()).cutoff_freq(440).rack(&mut rack);
 
     let synth = Synth { sender, rack };
     let stream = audio_host

--- a/oscen-lib/README.md
+++ b/oscen-lib/README.md
@@ -1,6 +1,6 @@
 # Oscen [![crates.io](https://img.shields.io/crates/v/oscen.svg)](https://crates.io/crates/oscen)
 
-Oscen [“oh-sin”] is a library for building modular synthesizers in Rust.
+Oscen [oh-sin] is a library for building modular synthesizers in Rust.
 
 It contains a collection of components frequently used in sound synthesis
 such as oscillators, filters, and envelope generators. It lets you

--- a/oscen-lib/src/instruments.rs
+++ b/oscen-lib/src/instruments.rs
@@ -80,40 +80,40 @@ impl WaveGuide {
     }
 
     pub fn on(&mut self) {
-        self.envelope.lock().unwrap().on();
+        self.envelope.lock().on();
     }
 
     pub fn off(&mut self) {
-        self.envelope.lock().unwrap().off();
+        self.envelope.lock().off();
     }
 
     pub fn attack<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.envelope.lock().unwrap().attack(arg);
+        self.envelope.lock().attack(arg);
         self
     }
 
     pub fn decay<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.envelope.lock().unwrap().decay(arg);
+        self.envelope.lock().decay(arg);
         self
     }
 
     pub fn sustain<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.envelope.lock().unwrap().sustain(arg);
+        self.envelope.lock().sustain(arg);
         self
     }
 
     pub fn release<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.envelope.lock().unwrap().release(arg);
+        self.envelope.lock().release(arg);
         self
     }
 
     pub fn cutoff_freq<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.lpf.lock().unwrap().cutoff_freq(arg);
+        self.lpf.lock().cutoff_freq(arg);
         self
     }
 
     pub fn wet_decay<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.mixer.lock().unwrap().level_nth(1, arg.into());
+        self.mixer.lock().level_nth(1, arg.into());
         self
     }
 }
@@ -126,9 +126,9 @@ impl Signal for WaveGuide {
     std_signal!();
     fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
         let input = rack.output(self.burst);
-        self.input.lock().unwrap().value(input);
+        self.input.lock().value(input);
         let dt = 1.0 / f64::max(1.0, In::val(&rack, self.hz));
-        self.delay.lock().unwrap().delay_time(dt);
+        self.delay.lock().delay_time(dt);
         self.rack.signal(sample_rate)
     }
 }

--- a/oscen-lib/src/instruments.rs
+++ b/oscen-lib/src/instruments.rs
@@ -2,9 +2,9 @@ use super::{
     envelopes::Adsr,
     filters::Lpf,
     operators::{Delay, Mixer, Product},
-    signal::{mk_tag, ArcMutex, Builder, In, Link, Rack, Real, Signal, Tag, Gate},
+    signal::{mk_tag, ArcMutex, Builder, Gate, In, Link, Rack, Real, Signal, Tag},
 };
-use crate::{as_any_mut, std_signal, gate};
+use crate::{as_any_mut, gate, std_signal};
 use std::any::Any;
 
 #[derive(Clone)]
@@ -132,4 +132,3 @@ impl Signal for WaveGuide {
         self.rack.signal(sample_rate)
     }
 }
-

--- a/oscen-lib/src/operators.rs
+++ b/oscen-lib/src/operators.rs
@@ -315,9 +315,9 @@ impl IndexMut<&str> for CrossFade {
 pub struct Modulator {
     tag: Tag,
     wave: In,
-    base_hz: In,
-    mod_hz: In,
-    mod_idx: In,
+    hz: In,
+    ratio: In,
+    index: In,
 }
 
 impl Modulator {
@@ -325,9 +325,10 @@ impl Modulator {
         Modulator {
             tag: mk_tag(),
             wave: wave.into(),
-            base_hz: 0.into(),
-            mod_hz: 0.into(),
-            mod_idx: 0.into(),
+            hz: 0.into(),
+            /// modulator frequency / carrier frequency
+            ratio: 0.into(),
+            index: 0.into(),
         }
     }
 
@@ -336,18 +337,18 @@ impl Modulator {
         self
     }
 
-    pub fn base_hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.base_hz = arg.into();
+    pub fn hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
+        self.hz = arg.into();
         self
     }
 
-    pub fn mod_hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.mod_hz = arg.into();
+    pub fn ratio<T: Into<In>>(&mut self, arg: T) -> &mut Self {
+        self.ratio = arg.into();
         self
     }
 
-    pub fn mod_idx<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.mod_idx = arg.into();
+    pub fn index<T: Into<In>>(&mut self, arg: T) -> &mut Self {
+        self.index = arg.into();
         self
     }
 }
@@ -357,10 +358,10 @@ impl Builder for Modulator {}
 impl Signal for Modulator {
     std_signal!();
     fn signal(&mut self, rack: &Rack, _sample_rate: Real) -> Real {
-        let mod_hz = In::val(rack, self.mod_hz);
-        let mod_idx = In::val(rack, self.mod_idx);
-        let base_hz = In::val(rack, self.base_hz);
-        base_hz + mod_idx * mod_hz * In::val(rack, self.wave)
+        let ratio = In::val(rack, self.ratio);
+        let index = In::val(rack, self.index);
+        let hz = In::val(rack, self.hz);
+        hz + index * hz * ratio * In::val(rack, self.wave)
     }
 }
 
@@ -370,9 +371,9 @@ impl Index<&str> for Modulator {
     fn index(&self, index: &str) -> &Self::Output {
         match index {
             "wave" => &self.wave,
-            "base_hz" => &self.base_hz,
-            "mod_hz" => &self.mod_hz,
-            "mod_idx" => &self.mod_idx,
+            "base_hz" => &self.hz,
+            "mod_hz" => &self.ratio,
+            "mod_idx" => &self.index,
             _ => panic!("Modulator only does not have a field named:  {}", index),
         }
     }
@@ -382,9 +383,9 @@ impl IndexMut<&str> for Modulator {
     fn index_mut(&mut self, index: &str) -> &mut Self::Output {
         match index {
             "wave" => &mut self.wave,
-            "base_hz" => &mut self.base_hz,
-            "mod_hz" => &mut self.mod_hz,
-            "mod_idx" => &mut self.mod_idx,
+            "base_hz" => &mut self.hz,
+            "mod_hz" => &mut self.ratio,
+            "mod_idx" => &mut self.index,
             _ => panic!("Modulator only does not have a field named:  {}", index),
         }
     }

--- a/oscen-lib/src/operators.rs
+++ b/oscen-lib/src/operators.rs
@@ -330,11 +330,16 @@ pub struct Modulator {
 }
 
 impl Modulator {
-    pub fn new(signal_fn: SignalFn, hz: In, ratio: In, index: In) -> Self {
+    pub fn new<H, R, I>(signal_fn: SignalFn, hz: H, ratio: R, index: I) -> Self
+    where
+        H: Into<In> + Copy,
+        R: Into<In> + Copy,
+        I: Into<In> + Copy,
+    {
         let mut rack = Rack::new(vec![]);
-        let hz_osc = ConstOsc::new(hz).rack(&mut rack);
-        let ratio_osc = ConstOsc::new(ratio).rack(&mut rack);
-        let index_osc = ConstOsc::new(index).rack(&mut rack);
+        let hz_osc = ConstOsc::new(hz.into()).rack(&mut rack);
+        let ratio_osc = ConstOsc::new(ratio.into()).rack(&mut rack);
+        let index_osc = ConstOsc::new(index.into()).rack(&mut rack);
         let mod_hz = Product::new(vec![ratio_osc.tag(), hz_osc.tag()]).rack(&mut rack);
         let amp_factor =
             Product::new(vec![index_osc.tag(), hz_osc.tag(), ratio_osc.tag()]).rack(&mut rack);
@@ -347,10 +352,10 @@ impl Modulator {
         Modulator {
             tag: mk_tag(),
             wave,
-            hz,
+            hz: hz.into(),
             /// modulator frequency / carrier frequency
-            ratio,
-            index,
+            ratio: ratio.into(),
+            index: index.into(),
             hz_osc,
             ratio_osc,
             index_osc,

--- a/oscen-lib/src/operators.rs
+++ b/oscen-lib/src/operators.rs
@@ -1,4 +1,4 @@
-use super::oscillators::{ConstOsc, SignalFn, StdOsc};
+use super::oscillators::{ConstOsc, SignalFn, Oscillator};
 use super::signal::*;
 use super::utils::RingBuffer;
 use crate::{as_any_mut, std_signal};
@@ -315,7 +315,7 @@ impl IndexMut<&str> for CrossFade {
 #[derive(Clone)]
 pub struct Modulator {
     tag: Tag,
-    wave: ArcMutex<StdOsc>,
+    wave: ArcMutex<Oscillator>,
     hz: In,
     ratio: In,
     index: In,
@@ -344,7 +344,7 @@ impl Modulator {
         let amp_factor =
             Product::new(vec![index_osc.tag(), hz_osc.tag(), ratio_osc.tag()]).rack(&mut rack);
         let mod_amp = Mixer::new(vec![hz_osc.tag(), amp_factor.tag()]).rack(&mut rack);
-        let wave = StdOsc::new(signal_fn)
+        let wave = Oscillator::new(signal_fn)
             .hz(mod_hz.tag())
             .amplitude(mod_amp.tag())
             .rack(&mut rack);

--- a/oscen-lib/src/operators.rs
+++ b/oscen-lib/src/operators.rs
@@ -1,3 +1,4 @@
+use super::oscillators::{ConstOsc, SignalFn, StdOsc};
 use super::signal::*;
 use super::utils::RingBuffer;
 use crate::{as_any_mut, std_signal};
@@ -311,45 +312,54 @@ impl IndexMut<&str> for CrossFade {
 /// A `Modulator` is designed to be the input to the `hz` field of a carrier
 /// wave. It takes control of the carriers frequency and modulates it's base
 /// hz by adding mod_idx * mod_hz * output of modulator wave.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Modulator {
     tag: Tag,
-    wave: In,
+    wave: ArcMutex<StdOsc>,
     hz: In,
     ratio: In,
     index: In,
+    hz_osc: ArcMutex<ConstOsc>,
+    ratio_osc: ArcMutex<ConstOsc>,
+    index_osc: ArcMutex<ConstOsc>,
+    mod_hz: ArcMutex<Product>,
+    amp_factor: ArcMutex<Product>,
+    mod_amp: ArcMutex<Mixer>,
+    carrier_hz: ArcMutex<Mixer>,
+    rack: Rack,
 }
 
 impl Modulator {
-    pub fn new(wave: Tag) -> Self {
+    pub fn new(signal_fn: SignalFn, hz: In, ratio: In, index: In) -> Self {
+        let mut rack = Rack::new(vec![]);
+        let hz_osc = ConstOsc::new(hz).rack(&mut rack);
+        let ratio_osc = ConstOsc::new(ratio).rack(&mut rack);
+        let index_osc = ConstOsc::new(index).rack(&mut rack);
+        let mod_hz = Product::new(vec![ratio_osc.tag(), hz_osc.tag()]).rack(&mut rack);
+        let amp_factor =
+            Product::new(vec![index_osc.tag(), hz_osc.tag(), ratio_osc.tag()]).rack(&mut rack);
+        let mod_amp = Mixer::new(vec![hz_osc.tag(), amp_factor.tag()]).rack(&mut rack);
+        let wave = StdOsc::new(signal_fn)
+            .hz(mod_hz.tag())
+            .amplitude(mod_amp.tag())
+            .rack(&mut rack);
+        let carrier_hz = Mixer::new(vec![wave.tag(), hz_osc.tag()]).rack(&mut rack);
         Modulator {
             tag: mk_tag(),
-            wave: wave.into(),
-            hz: 0.into(),
+            wave,
+            hz,
             /// modulator frequency / carrier frequency
-            ratio: 0.into(),
-            index: 0.into(),
+            ratio,
+            index,
+            hz_osc,
+            ratio_osc,
+            index_osc,
+            mod_hz,
+            amp_factor,
+            mod_amp,
+            carrier_hz,
+            rack,
         }
-    }
-
-    pub fn wave<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.wave = arg.into();
-        self
-    }
-
-    pub fn hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.hz = arg.into();
-        self
-    }
-
-    pub fn ratio<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.ratio = arg.into();
-        self
-    }
-
-    pub fn index<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.index = arg.into();
-        self
     }
 }
 
@@ -357,11 +367,8 @@ impl Builder for Modulator {}
 
 impl Signal for Modulator {
     std_signal!();
-    fn signal(&mut self, rack: &Rack, _sample_rate: Real) -> Real {
-        let ratio = In::val(rack, self.ratio);
-        let index = In::val(rack, self.index);
-        let hz = In::val(rack, self.hz);
-        hz + index * hz * ratio * In::val(rack, self.wave)
+    fn signal(&mut self, _rack: &Rack, sample_rate: Real) -> Real {
+        self.rack.signal(sample_rate)
     }
 }
 
@@ -370,10 +377,9 @@ impl Index<&str> for Modulator {
 
     fn index(&self, index: &str) -> &Self::Output {
         match index {
-            "wave" => &self.wave,
-            "base_hz" => &self.hz,
-            "mod_hz" => &self.ratio,
-            "mod_idx" => &self.index,
+            "hz" => &self.hz,
+            "ratio" => &self.ratio,
+            "index" => &self.index,
             _ => panic!("Modulator only does not have a field named:  {}", index),
         }
     }
@@ -382,10 +388,9 @@ impl Index<&str> for Modulator {
 impl IndexMut<&str> for Modulator {
     fn index_mut(&mut self, index: &str) -> &mut Self::Output {
         match index {
-            "wave" => &mut self.wave,
-            "base_hz" => &mut self.hz,
-            "mod_hz" => &mut self.ratio,
-            "mod_idx" => &mut self.index,
+            "hz" => &mut self.hz,
+            "ratio" => &mut self.ratio,
+            "index" => &mut self.index,
             _ => panic!("Modulator only does not have a field named:  {}", index),
         }
     }

--- a/oscen-lib/src/oscillators.rs
+++ b/oscen-lib/src/oscillators.rs
@@ -474,7 +474,6 @@ impl Signal for FourierOsc {
             if let Some(v) = node
                 .module
                 .lock()
-                .unwrap()
                 .as_any_mut()
                 .downcast_mut::<Oscillator>()
             {

--- a/oscen-lib/src/oscillators.rs
+++ b/oscen-lib/src/oscillators.rs
@@ -43,270 +43,25 @@ impl Signal for Clock {
     }
 }
 
-/// A basic sine oscillator.
 #[derive(Copy, Clone)]
-pub struct SineOsc {
+pub struct StdOsc {
     tag: Tag,
     hz: In,
     amplitude: In,
     phase: In,
+    arg: In,
+    signal_fn: fn(Real, Real) -> Real,
 }
 
-impl SineOsc {
-    pub fn new() -> Self {
+impl StdOsc {
+    pub fn new(signal_fn: fn(Real, Real) -> Real) -> Self {
         Self {
             tag: mk_tag(),
             hz: 0.into(),
             amplitude: 1.into(),
             phase: 0.into(),
-        }
-    }
-
-    pub fn hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.hz = arg.into();
-        self
-    }
-
-    pub fn amplitude<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.amplitude = arg.into();
-        self
-    }
-
-    pub fn phase<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.phase = arg.into();
-        self
-    }
-}
-
-impl Builder for SineOsc {}
-
-impl Signal for SineOsc {
-    std_signal!();
-    fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
-        let hz = In::val(rack, self.hz);
-        let amplitude = In::val(rack, self.amplitude);
-        let phase = In::val(rack, self.phase);
-        match &self.phase {
-            In::Fix(p) => {
-                let mut ph = *p + hz / sample_rate;
-                ph %= sample_rate;
-                self.phase = In::Fix(ph);
-            }
-            In::Cv(_) => {}
-        };
-        amplitude * (TAU * phase).sin()
-    }
-}
-
-impl Index<&str> for SineOsc {
-    type Output = In;
-
-    fn index(&self, index: &str) -> &Self::Output {
-        match index {
-            "hz" => &self.hz,
-            "amp" => &self.amplitude,
-            "phase" => &self.phase,
-            _ => panic!("SineOsc does not have a field named:  {}", index),
-        }
-    }
-}
-
-impl IndexMut<&str> for SineOsc {
-    fn index_mut(&mut self, index: &str) -> &mut Self::Output {
-        match index {
-            "hz" => &mut self.hz,
-            "amp" => &mut self.amplitude,
-            "phase" => &mut self.phase,
-            _ => panic!("SineOsc does not have a field named:  {}", index),
-        }
-    }
-}
-
-/// Saw wave oscillator.
-#[derive(Copy, Clone)]
-pub struct SawOsc {
-    tag: Tag,
-    hz: In,
-    amplitude: In,
-    phase: In,
-}
-
-impl SawOsc {
-    pub fn new() -> Self {
-        Self {
-            tag: mk_tag(),
-            hz: 0.into(),
-            amplitude: 1.into(),
-            phase: 0.into(),
-        }
-    }
-
-    pub fn hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.hz = arg.into();
-        self
-    }
-
-    pub fn amplitude<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.amplitude = arg.into();
-        self
-    }
-
-    pub fn phase<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.phase = arg.into();
-        self
-    }
-}
-
-impl Builder for SawOsc {}
-
-impl Signal for SawOsc {
-    std_signal!();
-    fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
-        let hz = In::val(rack, self.hz);
-        let amplitude = In::val(rack, self.amplitude);
-        let phase = In::val(rack, self.phase);
-        match &self.phase {
-            In::Fix(p) => {
-                let mut ph = *p + hz / sample_rate;
-                ph %= sample_rate;
-                self.phase = In::Fix(ph);
-            }
-            In::Cv(_) => {}
-        };
-        let t = phase - 0.5;
-        let s = -t - floor(0.5 - t, 0);
-        if s < -0.5 {
-            0.0
-        } else {
-            amplitude * 2.0 * s
-        }
-    }
-}
-
-impl Index<&str> for SawOsc {
-    type Output = In;
-
-    fn index(&self, index: &str) -> &Self::Output {
-        match index {
-            "hz" => &self.hz,
-            "amp" => &self.amplitude,
-            "phase" => &self.phase,
-            _ => panic!("SawOsc does not have a field named:  {}", index),
-        }
-    }
-}
-
-impl IndexMut<&str> for SawOsc {
-    fn index_mut(&mut self, index: &str) -> &mut Self::Output {
-        match index {
-            "hz" => &mut self.hz,
-            "amp" => &mut self.amplitude,
-            "phase" => &mut self.phase,
-            _ => panic!("SawOsc does not have a field named:  {}", index),
-        }
-    }
-}
-
-/// Triangle wave oscillator.
-#[derive(Copy, Clone)]
-pub struct TriangleOsc {
-    tag: Tag,
-    hz: In,
-    amplitude: In,
-    phase: In,
-}
-
-impl TriangleOsc {
-    pub fn new() -> Self {
-        Self {
-            tag: mk_tag(),
-            hz: 0.into(),
-            amplitude: 1.into(),
-            phase: 0.into(),
-        }
-    }
-
-    pub fn hz<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.hz = arg.into();
-        self
-    }
-
-    pub fn amplitude<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.amplitude = arg.into();
-        self
-    }
-
-    pub fn phase<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.phase = arg.into();
-        self
-    }
-}
-
-impl Builder for TriangleOsc {}
-
-impl Signal for TriangleOsc {
-    std_signal!();
-    fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
-        let hz = In::val(rack, self.hz);
-        let amplitude = In::val(rack, self.amplitude);
-        let phase = In::val(rack, self.phase);
-        match &self.phase {
-            In::Fix(p) => {
-                let mut ph = *p + hz / sample_rate;
-                ph %= sample_rate;
-                self.phase = In::Fix(ph);
-            }
-            In::Cv(_) => {}
-        };
-        let t = phase - 0.75;
-        let saw_amp = 2. * (-t - floor(0.5 - t, 0));
-        (2. * saw_amp.abs() - amplitude) * amplitude
-    }
-}
-
-impl Index<&str> for TriangleOsc {
-    type Output = In;
-
-    fn index(&self, index: &str) -> &Self::Output {
-        match index {
-            "hz" => &self.hz,
-            "amp" => &self.amplitude,
-            "phase" => &self.phase,
-            _ => panic!("TriangleOsc does not have a field named:  {}", index),
-        }
-    }
-}
-
-impl IndexMut<&str> for TriangleOsc {
-    fn index_mut(&mut self, index: &str) -> &mut Self::Output {
-        match index {
-            "hz" => &mut self.hz,
-            "amp" => &mut self.amplitude,
-            "phase" => &mut self.phase,
-            _ => panic!("TriangleOsc does not have a field named:  {}", index),
-        }
-    }
-}
-
-/// Square (Pulse) wave oscillator with a `duty_cycle` that takes values in (0, 1),
-/// that determines the pulse width.
-#[derive(Copy, Clone)]
-pub struct SquareOsc {
-    tag: Tag,
-    hz: In,
-    amplitude: In,
-    phase: In,
-    duty_cycle: In,
-}
-
-impl SquareOsc {
-    pub fn new() -> Self {
-        Self {
-            tag: mk_tag(),
-            hz: 0.into(),
-            amplitude: 1.into(),
-            phase: 0.into(),
-            duty_cycle: (0.5).into(),
+            arg: 0.into(),
+            signal_fn,
         }
     }
 
@@ -325,20 +80,21 @@ impl SquareOsc {
         self
     }
 
-    pub fn duty_cycle<T: Into<In>>(&mut self, arg: T) -> &mut Self {
-        self.duty_cycle = arg.into();
+    pub fn arg<T: Into<In>>(&mut self, arg: T) -> &mut Self {
+        self.arg = arg.into();
         self
     }
 }
 
-impl Builder for SquareOsc {}
+impl Builder for StdOsc {}
 
-impl Signal for SquareOsc {
+impl Signal for StdOsc {
     std_signal!();
     fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
         let hz = In::val(rack, self.hz);
         let amplitude = In::val(rack, self.amplitude);
         let phase = In::val(rack, self.phase);
+        let arg = In::val(rack, self.arg);
         match &self.phase {
             In::Fix(p) => {
                 let mut ph = *p + hz / sample_rate;
@@ -347,17 +103,11 @@ impl Signal for SquareOsc {
             }
             In::Cv(_) => {}
         };
-        let duty_cycle = In::val(rack, self.duty_cycle);
-        let t = phase - floor(phase, 0);
-        if t <= duty_cycle {
-            amplitude
-        } else {
-            -amplitude
-        }
+        amplitude * (self.signal_fn)(phase, arg)
     }
 }
 
-impl Index<&str> for SquareOsc {
+impl Index<&str> for StdOsc {
     type Output = In;
 
     fn index(&self, index: &str) -> &Self::Output {
@@ -365,20 +115,51 @@ impl Index<&str> for SquareOsc {
             "hz" => &self.hz,
             "amp" => &self.amplitude,
             "phase" => &self.phase,
-            _ => panic!("SquareOsc does not have a field named:  {}", index),
+            "arg" => &self.arg,
+            _ => panic!("StandardOsc does not have a field named:  {}", index),
         }
     }
 }
 
-impl IndexMut<&str> for SquareOsc {
+impl IndexMut<&str> for StdOsc {
     fn index_mut(&mut self, index: &str) -> &mut Self::Output {
         match index {
             "hz" => &mut self.hz,
             "amp" => &mut self.amplitude,
             "phase" => &mut self.phase,
-            _ => panic!("SquareOsc does not have a field named:  {}", index),
+            "arg" => &mut self.arg,
+            _ => panic!("StandardOsc does not have a field named:  {}", index),
         }
     }
+}
+
+pub fn sine_osc(phase: Real, _: Real) -> Real {
+    (phase * TAU).sin()
+}
+
+pub fn square_osc(phase: Real, duty_cycle: Real) -> Real {
+    let t = phase - floor(phase, 0);
+    if t <= duty_cycle {
+        1.0
+    } else {
+        -1.0
+    }
+}
+
+pub fn saw_osc(phase: Real, _: Real) -> Real {
+    let t = phase - 0.5;
+    let s = -t - floor(0.5 - t, 0);
+    if s < -0.5 {
+        0.0
+    } else {
+        2.0 * s
+    }
+}
+
+pub fn triangle_osc(phase: Real, _: Real) -> Real {
+    let t = phase - 0.75;
+    let saw_amp = 2. * (-t - floor(0.5 - t, 0));
+    2. * saw_amp.abs() - 1.0
 }
 
 /// Choose between Normal(0,1) and Uniforem distributions for `WhiteNoise`.
@@ -454,7 +235,7 @@ impl IndexMut<&str> for WhiteNoise {
 
 /// Pink noise oscillator.
 // Paul Kellet's pk3 as in:
-// paul.kellett@maxim.abel.co.uk, http://www.abel.co.uk/~maxim/ 
+// paul.kellett@maxim.abel.co.uk, http://www.abel.co.uk/~maxim/
 #[derive(Copy, Clone)]
 pub struct PinkNoise {
     tag: Tag,
@@ -616,7 +397,7 @@ impl FourierOsc {
         let sigma = lanczos as i32;
         let mut wwaves: Vec<ArcMutex<Sig>> = Vec::new();
         for (n, c) in coefficients.iter().enumerate() {
-            let mut s = SineOsc::new();
+            let mut s = StdOsc::new(sine_osc);
             s.amplitude =
                 (*c * sinc(sigma as Real * n as Real / coefficients.len() as Real)).into();
             wwaves.push(arc(s));
@@ -659,13 +440,17 @@ impl Signal for FourierOsc {
                 .lock()
                 .unwrap()
                 .as_any_mut()
-                .downcast_mut::<SineOsc>()
+                .downcast_mut::<StdOsc>()
             {
                 v.hz = (hz * n as Real).into();
             }
         }
         self.sines.signal(sample_rate);
-        let out = self.sines.modules.iter().fold(0., |acc, x| acc + x.1.output);
+        let out = self
+            .sines
+            .modules
+            .iter()
+            .fold(0., |acc, x| acc + x.1.output);
         amp * out
     }
 }

--- a/oscen-lib/src/oscillators.rs
+++ b/oscen-lib/src/oscillators.rs
@@ -9,7 +9,8 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-/// An synth module that returns a constant In value.
+/// An synth module that returns a constant In value. Useful for example to
+/// multiply or add constants to oscillators.
 #[derive(Copy, Clone)]
 pub struct ConstOsc {
     tag: Tag,

--- a/oscen-lib/src/oscillators.rs
+++ b/oscen-lib/src/oscillators.rs
@@ -77,7 +77,7 @@ impl Signal for Clock {
 pub type SignalFn = fn(Real, Real) -> Real;
 
 #[derive(Copy, Clone)]
-pub struct StdOsc {
+pub struct Oscillator {
     tag: Tag,
     hz: In,
     amplitude: In,
@@ -86,7 +86,7 @@ pub struct StdOsc {
     signal_fn: fn(Real, Real) -> Real,
 }
 
-impl StdOsc {
+impl Oscillator {
     pub fn new(signal_fn: SignalFn) -> Self {
         Self {
             tag: mk_tag(),
@@ -119,9 +119,9 @@ impl StdOsc {
     }
 }
 
-impl Builder for StdOsc {}
+impl Builder for Oscillator {}
 
-impl Signal for StdOsc {
+impl Signal for Oscillator {
     std_signal!();
     fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
         let hz = In::val(rack, self.hz);
@@ -143,7 +143,7 @@ impl Signal for StdOsc {
     }
 }
 
-impl Index<&str> for StdOsc {
+impl Index<&str> for Oscillator {
     type Output = In;
 
     fn index(&self, index: &str) -> &Self::Output {
@@ -157,7 +157,7 @@ impl Index<&str> for StdOsc {
     }
 }
 
-impl IndexMut<&str> for StdOsc {
+impl IndexMut<&str> for Oscillator {
     fn index_mut(&mut self, index: &str) -> &mut Self::Output {
         match index {
             "hz" => &mut self.hz,
@@ -433,7 +433,7 @@ impl FourierOsc {
         let sigma = lanczos as i32;
         let mut wwaves: Vec<ArcMutex<Sig>> = Vec::new();
         for (n, c) in coefficients.iter().enumerate() {
-            let mut s = StdOsc::new(sine_osc);
+            let mut s = Oscillator::new(sine_osc);
             s.amplitude =
                 (*c * sinc(sigma as Real * n as Real / coefficients.len() as Real)).into();
             wwaves.push(arc(s));
@@ -476,7 +476,7 @@ impl Signal for FourierOsc {
                 .lock()
                 .unwrap()
                 .as_any_mut()
-                .downcast_mut::<StdOsc>()
+                .downcast_mut::<Oscillator>()
             {
                 v.hz = (hz * n as Real).into();
             }

--- a/oscen-lib/src/reverb.rs
+++ b/oscen-lib/src/reverb.rs
@@ -178,7 +178,7 @@ impl Signal for Freeverb {
     std_signal!();
     fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
         let inp = rack.output(self.wave);
-        self.input.lock().unwrap().value(inp);
+        self.input.lock().value(inp);
         let out = self.rack.signal(sample_rate);
         out * self.wet_gain + inp * self.dry
     }

--- a/oscen-lib/src/signal.rs
+++ b/oscen-lib/src/signal.rs
@@ -259,7 +259,10 @@ impl Rack {
             nodes.insert(t, SynthModule::new(s));
             order.push(t)
         }
-        Rack { modules: nodes, order }
+        Rack {
+            modules: nodes,
+            order,
+        }
     }
 
     /// Convert a rack into an `Iter` - note: we don't need an `iter_mut` since

--- a/oscen-lib/src/signal.rs
+++ b/oscen-lib/src/signal.rs
@@ -3,8 +3,9 @@ use std::{
     collections::HashMap,
     f64::consts::PI,
     ops::{Index, IndexMut},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
+use parking_lot::Mutex;
 use uuid::Uuid;
 
 pub const TAU: f64 = 2.0 * PI;
@@ -70,7 +71,6 @@ macro_rules! gate {
                 if let Some(v) = rack.modules[&n]
                     .module
                     .lock()
-                    .unwrap()
                     .as_any_mut()
                     .downcast_mut::<Self>()
                 {
@@ -82,7 +82,6 @@ macro_rules! gate {
                 if let Some(v) = rack.modules[&n]
                     .module
                     .lock()
-                    .unwrap()
                     .as_any_mut()
                     .downcast_mut::<Self>()
                 {
@@ -109,22 +108,22 @@ where
 {
     as_any_mut!();
     fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
-        self.lock().unwrap().signal(rack, sample_rate)
+        self.lock().signal(rack, sample_rate)
     }
 
     fn tag(&self) -> Tag {
-        self.lock().unwrap().tag()
+        self.lock().tag()
     }
 }
 
 impl Signal for ArcMutex<dyn Signal + Send> {
     as_any_mut!();
     fn signal(&mut self, rack: &Rack, sample_rate: Real) -> Real {
-        self.lock().unwrap().signal(rack, sample_rate)
+        self.lock().signal(rack, sample_rate)
     }
 
     fn tag(&self) -> Tag {
-        self.lock().unwrap().tag()
+        self.lock().tag()
     }
 }
 
@@ -255,7 +254,7 @@ impl Rack {
         let mut nodes: HashMap<Tag, SynthModule> = HashMap::new();
         let mut order: Vec<Tag> = Vec::new();
         for s in ws {
-            let t = s.lock().unwrap().tag();
+            let t = s.lock().tag();
             nodes.insert(t, SynthModule::new(s));
             order.push(t)
         }
@@ -342,7 +341,6 @@ impl Rack {
             outs.push(
                 node.module
                     .lock()
-                    .expect("Function rack::signal could not find tag in first loop")
                     .signal(&self, sample_rate),
             )
         }


### PR DESCRIPTION
- Create a `StdOsc` struct instead of various standard oscillators: sine, saw, square, triangle, etc.
- Redo `Modulator` so that both timbre remains constant at different frequencies