### PR TITLE
Fix graph compiler correctness bugs

### DIFF
--- a/oscen-graph-compiler/src/codegen/emit_node.rs
+++ b/oscen-graph-compiler/src/codegen/emit_node.rs
@@ -500,6 +500,16 @@ impl<'a> CodegenContext<'a> {
                                     );
                                 });
                             }
+                        } else if Self::is_simple_endpoint_source(source) {
+                            // Bare graph event input forwarded to a graph
+                            // event output (`midi -> thru;`): copy the queue.
+                            let source_tokens = self.emit_expr(source);
+                            out.push(quote! {
+                                <() as ::oscen::graph::ConnectEndpoints<_, _>>::connect(
+                                    &#source_tokens,
+                                    &mut self.#dest_ident
+                                );
+                            });
                         }
                     }
                     // Asset endpoints are bound from externals, never driven as

--- a/oscen-graph-compiler/src/codegen/emit_node.rs
+++ b/oscen-graph-compiler/src/codegen/emit_node.rs
@@ -9,7 +9,7 @@ use quote::{quote, quote_spanned};
 use std::collections::HashSet;
 use syn::Result;
 
-use super::helpers::root_node_name;
+use super::helpers::{is_same_rate_kernel, root_node_name};
 use super::CodegenContext;
 
 /// How a stream destination's incoming edges should be emitted, after
@@ -570,24 +570,26 @@ impl<'a> CodegenContext<'a> {
             }
         }
 
-        // Propagate through Same-rate edges until fixpoint.
+        // Propagate through same-rate edges (including same-rate event edges)
+        // until fixpoint. A compound source taints its destination if ANY
+        // node it references is tainted, not just the leftmost — otherwise
+        // `a.out + d.out -> mix.in` with a tainted `d` would leave `mix`
+        // pre-inner, reading `d`'s previous-frame output.
         let mut changed = true;
         while changed {
             changed = false;
             for (_, edge) in self.edges() {
-                if !matches!(edge.kernel, EdgeKernel::None) {
+                if !is_same_rate_kernel(&edge.kernel) {
                     continue;
                 }
-                let (Some(src), Some(dst)) = (
-                    root_node_name(&edge.source, self.ir),
-                    Some(self.ir.nodes[edge.dest.node].name.to_string()),
-                ) else {
-                    continue;
-                };
-                if !same_rate(&dst) {
+                let dst = self.ir.nodes[edge.dest.node].name.to_string();
+                if !same_rate(&dst) || tainted.contains(&dst) {
                     continue;
                 }
-                if tainted.contains(&src) && !tainted.contains(&dst) {
+                let src_tainted = crate::ir::lower::collect_referenced_node_ids(&edge.source)
+                    .into_iter()
+                    .any(|id| tainted.contains(&self.ir.nodes[id].name.to_string()));
+                if src_tainted {
                     tainted.insert(dst);
                     changed = true;
                 }

--- a/oscen-graph-compiler/src/codegen/emit_node.rs
+++ b/oscen-graph-compiler/src/codegen/emit_node.rs
@@ -124,24 +124,13 @@ impl<'a> CodegenContext<'a> {
     }
 
     /// The source-access expression a scalar connect would read, e.g.
-    /// `self.osc.output` (node endpoint) or `self.dry` (graph input). Used as a
-    /// single term of a fan-in sum. The source is known simple + scalar.
+    /// `self.osc.output` (node endpoint), `self.dry` (graph input), or
+    /// `self.voices[0].output` (indexed array element). Used as a single term
+    /// of a fan-in sum. The source is known simple + scalar; `emit_expr`
+    /// already handles ramped graph inputs (`.current`) and element/channel
+    /// indices.
     fn simple_source_access_tokens(&self, source: &crate::ir::expr::IrExpr) -> TokenStream {
-        let source_ident = self
-            .extract_root_node(source)
-            .expect("simple scalar source has a root node");
-        let source_field = self.extract_endpoint_field(source);
-        let source_access = if self.is_input(source_ident)
-            && source_field.is_none()
-            && self.is_ramped_input(source_ident).is_some()
-        {
-            quote! { .current }
-        } else if let Some(field) = source_field {
-            quote! { .#field }
-        } else {
-            quote! {}
-        };
-        quote! { self.#source_ident #source_access }
+        self.emit_expr(source)
     }
 
     /// Emit a fan-in sum into `dst` (the destination lvalue `self.node.field`
@@ -304,10 +293,29 @@ impl<'a> CodegenContext<'a> {
                     }
                 }
 
+                // An index on a node-array endpoint (`voices[0].output` /
+                // `voices[2].frequency`) addresses a single element; such
+                // edges are classified Scalar during lowering. Route them
+                // through the endpoint emitters, which produce the `[k]`
+                // element access on the indexed side.
+                let src_elem_indexed = Self::ir_expr_as_endpoint(source)
+                    .and_then(|ep| ep.index)
+                    .filter(|_| self.get_node_array_size(source_ident).is_some())
+                    .is_some();
+                if src_elem_indexed || dest.index.is_some() {
+                    let src_toks = self.emit_expr(source);
+                    let dst_toks = self.emit_endpoint(dest);
+                    assignments.push(quote! {
+                        <() as ::oscen::graph::ConnectEndpoints<_, _>>::connect(
+                            &#src_toks,
+                            &mut #dst_toks
+                        );
+                    });
+                    continue;
+                }
+
                 // A channel index on a scalar node's endpoint (`s.output[0]`)
-                // extracts one channel of its `Frame<N>` value. (An index on a
-                // node-array element is handled via the `[i]` node position and
-                // keeps its existing access form.)
+                // extracts one channel of its `Frame<N>` value.
                 let channel_index = Self::ir_expr_as_endpoint(source)
                     .and_then(|ep| ep.index)
                     .filter(|_| self.get_node_array_size(source_ident).is_none());
@@ -455,19 +463,27 @@ impl<'a> CodegenContext<'a> {
                 let is_simple_source =
                     Self::is_simple_endpoint_source(source) && source_field.is_some();
 
+                // An index on the source endpoint selects one array element
+                // (or one frame channel); it must never fan in over the
+                // whole array.
+                let source_index = Self::ir_expr_as_endpoint(source).and_then(|ep| ep.index);
+
                 match output_kind {
                     EndpointKind::Stream | EndpointKind::Value => {
                         if is_simple_source {
                             let source_node = source_node.unwrap();
                             let source_field = source_field.unwrap();
-                            if let Some(_src_array_size) = self.get_node_array_size(source_node) {
+                            if self.get_node_array_size(source_node).is_some()
+                                && source_index.is_none()
+                            {
                                 out.push(quote! {
                                     self.#dest_ident = self.#source_node.iter().map(|n| n.#source_field).sum();
                                 });
                             } else {
+                                let source_tokens = self.emit_expr(source);
                                 out.push(quote! {
                                     <() as ::oscen::graph::ConnectEndpoints<_, _>>::connect(
-                                        &self.#source_node.#source_field,
+                                        &#source_tokens,
                                         &mut self.#dest_ident
                                     );
                                 });
@@ -483,7 +499,10 @@ impl<'a> CodegenContext<'a> {
                         if is_simple_source {
                             let source_node = source_node.unwrap();
                             let source_field = source_field.unwrap();
-                            if let Some(array_size) = self.get_node_array_size(source_node) {
+                            let array_size = self
+                                .get_node_array_size(source_node)
+                                .filter(|_| source_index.is_none());
+                            if let Some(array_size) = array_size {
                                 out.push(quote! {
                                     self.#dest_ident.clear();
                                     for i in 0..#array_size {
@@ -493,9 +512,10 @@ impl<'a> CodegenContext<'a> {
                                     }
                                 });
                             } else {
+                                let source_tokens = self.emit_expr(source);
                                 out.push(quote! {
                                     <() as ::oscen::graph::ConnectEndpoints<_, _>>::connect(
-                                        &self.#source_node.#source_field,
+                                        &#source_tokens,
                                         &mut self.#dest_ident
                                     );
                                 });

--- a/oscen-graph-compiler/src/codegen/mod.rs
+++ b/oscen-graph-compiler/src/codegen/mod.rs
@@ -519,8 +519,8 @@ impl<'a> CodegenContext<'a> {
         Ok(process_body)
     }
 
-    /// Generate event queue clearing statements for graph-level event inputs/outputs.
-    fn generate_event_clearing(&self) -> Vec<TokenStream> {
+    /// Generate event queue clearing statements for graph-level event inputs.
+    fn generate_event_input_clearing(&self) -> Vec<TokenStream> {
         let mut clearing = Vec::new();
         for node in self.inputs() {
             let name = &node.name;
@@ -530,6 +530,15 @@ impl<'a> CodegenContext<'a> {
                 });
             }
         }
+        clearing
+    }
+
+    /// Generate event queue clearing statements for graph-level event outputs.
+    /// Outputs are cleared at the START of a processing cycle (not after it),
+    /// so events produced during the cycle stay readable by the host / an
+    /// outer graph until the next cycle begins.
+    fn generate_event_output_clearing(&self) -> Vec<TokenStream> {
+        let mut clearing = Vec::new();
         for node in self.outputs() {
             let name = &node.name;
             if matches!(self.output_kind(name), Some(EndpointKind::Event)) {
@@ -543,7 +552,8 @@ impl<'a> CodegenContext<'a> {
 
     /// Generate the static process() method for compile-time graphs.
     fn generate_static_process(&self) -> Result<TokenStream> {
-        let event_clearing = self.generate_event_clearing();
+        let event_input_clearing = self.generate_event_input_clearing();
+        let event_output_clearing = self.generate_event_output_clearing();
 
         if self.max_factor() > 1 {
             // Multi-rate graph nested as a node: the multi-rate inner-loop
@@ -553,10 +563,14 @@ impl<'a> CodegenContext<'a> {
                 #[inline(always)]
                 #[allow(unused_variables, unused_mut)]
                 pub fn process(&mut self) {
+                    // Clear event outputs from the previous cycle.
+                    #(#event_output_clearing)*
+
                     #body
 
-                    // Clear event queues after processing.
-                    #(#event_clearing)*
+                    // Clear event inputs after processing (outputs stay
+                    // readable until the next cycle).
+                    #(#event_input_clearing)*
                 }
             });
         }
@@ -567,13 +581,17 @@ impl<'a> CodegenContext<'a> {
             pub fn process(&mut self) {
                 use ::oscen::SignalProcessor as _;
 
+                // Clear event outputs from the previous cycle
+                #(#event_output_clearing)*
+
                 // Advance ramped value inputs
                 self.tick_ramps();
 
                 #(#process_body)*
 
-                // Clear event queues after processing
-                #(#event_clearing)*
+                // Clear event inputs after processing (outputs stay readable
+                // until the next cycle)
+                #(#event_input_clearing)*
             }
         })
     }
@@ -837,7 +855,7 @@ impl<'a> CodegenContext<'a> {
             })
             .collect();
 
-        let event_clearing = self.generate_event_clearing();
+        let event_input_clearing = self.generate_event_input_clearing();
 
         Ok(quote! {
             /// Process a block of `frames` samples with sub-block splitting at event boundaries.
@@ -871,8 +889,10 @@ impl<'a> CodegenContext<'a> {
                     self.__advance_one_frame(__frame);
                     __frame += 1;
 
-                    // Clear event queues so next sub-block starts clean
-                    #(#event_clearing)*
+                    // Clear event input queues so the next sub-block starts
+                    // clean (event outputs are overwritten per frame by the
+                    // output assignments and stay readable after the block)
+                    #(#event_input_clearing)*
                 }
             }
         })

--- a/oscen-graph-compiler/src/codegen/mod.rs
+++ b/oscen-graph-compiler/src/codegen/mod.rs
@@ -972,8 +972,13 @@ impl<'a> CodegenContext<'a> {
                         pub fn #set_ramp_name(&mut self, value: f32, frames: u32) {
                             // Only start a new ramp if target actually changed
                             if value != self.#name.target {
-                                if frames > 0 && !self.#name.is_ramping() {
-                                    self.active_ramps += 1;
+                                if frames > 0 {
+                                    if !self.#name.is_ramping() {
+                                        self.active_ramps += 1;
+                                    }
+                                } else if self.#name.is_ramping() {
+                                    // frames == 0 ends any in-flight ramp immediately.
+                                    self.active_ramps -= 1;
                                 }
                                 self.#name.set_with_ramp(value, frames);
                             }

--- a/oscen-graph-compiler/src/codegen/mod.rs
+++ b/oscen-graph-compiler/src/codegen/mod.rs
@@ -486,7 +486,13 @@ impl<'a> CodegenContext<'a> {
             Some(idx) => quote! { self.#node_name.#endpoint_name.0[#idx] },
             None => {
                 if ep.bare {
-                    quote! { self.#node_name }
+                    // A ramped graph value input is stored as a
+                    // `ValueRampState`; expressions read its `.current` f32.
+                    if self.is_ramped_input(node_name).is_some() {
+                        quote! { self.#node_name.current }
+                    } else {
+                        quote! { self.#node_name }
+                    }
                 } else {
                     quote! { self.#node_name.#endpoint_name }
                 }

--- a/oscen-graph-compiler/src/ir/expr/mod.rs
+++ b/oscen-graph-compiler/src/ir/expr/mod.rs
@@ -111,15 +111,19 @@ impl std::fmt::Debug for IrExprKind {
     }
 }
 
-/// Walk an `IrExpr` to find the leftmost endpoint's `NodeId`. Descends through
-/// `Binary` (left), `MethodCall` (receiver), and `Call` (first argument) so it
-/// agrees with `collect_referenced_node_ids`' ordering — the leftmost referenced
-/// node is the edge's primary source. Returns `None` only for a `Literal` or a
-/// `Call` with no node-referencing arguments.
+/// Walk an `IrExpr` to find the first endpoint's `NodeId` in left-to-right
+/// order. Descends through both sides of `Binary`, the receiver of
+/// `MethodCall` (args are opaque `syn::Expr`, so they can't reference
+/// endpoints), and every argument of `Call`, so it agrees with
+/// `collect_referenced_node_ids`' ordering — the first referenced node is the
+/// edge's primary source (e.g. `0.5 * g.output` anchors on `g`). Returns
+/// `None` only when the expression references no endpoint at all.
 pub(crate) fn primary_node(expr: &IrExpr) -> Option<NodeId> {
     match &expr.kind {
         IrExprKind::Endpoint(ep) => Some(ep.node),
-        IrExprKind::Binary { left, .. } => primary_node(left),
+        IrExprKind::Binary { left, right, .. } => {
+            primary_node(left).or_else(|| primary_node(right))
+        }
         IrExprKind::MethodCall { receiver, .. } => primary_node(receiver),
         IrExprKind::Call { args, .. } => args.iter().find_map(primary_node),
         IrExprKind::Literal(_) => None,

--- a/oscen-graph-compiler/src/ir/lower.rs
+++ b/oscen-graph-compiler/src/ir/lower.rs
@@ -793,17 +793,41 @@ fn analyze_rates(ir: &mut IrGraph, diags: &mut Diagnostics) {
 /// Per-node rate validation. Catches `Down(n)` rate annotations
 /// (currently unsupported) even on nodes with no edges. Mirrors the
 /// per-node check in `rate_analysis::analyze` so that unconnected
-/// undersampled nodes also produce a diagnostic.
+/// undersampled nodes also produce a diagnostic. Also rejects graphs
+/// mixing different `Up(n)` oversampling factors.
 fn validate_node_rates(ir: &IrGraph, diags: &mut Diagnostics) {
+    // Mixed `* N` factors are rejected for now: codegen runs the inner loop
+    // to the max factor while sizing and indexing each Up/Down edge buffer by
+    // its own edge's factor, so mixed factors would index out of bounds at
+    // runtime. Future upgrade path (clock division): gate each node's inner
+    // work on `__inner % (max / factor) == 0` and index its buffers by
+    // `__inner / (max / factor)`; factors are powers of two, so LCM == max.
+    let mut first_up: Option<u32> = None;
     for &id in &ir.processors {
         let node = &ir.nodes[id];
-        if let NodeRate::Down(n) = node.rate {
-            if n > 1 {
+        match node.rate {
+            NodeRate::Down(n) if n > 1 => {
                 diags.push_error(syn::Error::new(
                     node.span,
                     "node undersampling (`/ N`) is not yet supported in v1; only oversampling (`* N`) is implemented",
                 ));
             }
+            NodeRate::Up(n) => match first_up {
+                None => first_up = Some(n),
+                Some(m) if m != n => {
+                    diags.push_error(syn::Error::new(
+                        node.span,
+                        format!(
+                            "all oversampled nodes in a graph must use the same rate factor \
+                             (found `* {}` and `* {}`); use the highest factor for every \
+                             oversampled node",
+                            m, n
+                        ),
+                    ));
+                }
+                Some(_) => {}
+            },
+            _ => {}
         }
     }
 }

--- a/oscen-graph-compiler/src/ir/lower.rs
+++ b/oscen-graph-compiler/src/ir/lower.rs
@@ -502,6 +502,7 @@ fn build_edges(
                     stmt.policy,
                     stmt.span,
                     /*is_feedback=*/ false,
+                    diags,
                 );
             }
 
@@ -548,6 +549,7 @@ fn build_edges(
                     stmt.policy,
                     stmt.span,
                     /*is_feedback=*/ false,
+                    diags,
                 );
 
                 // Edge 2: via.output → dst  (feedback — breaks the cycle)
@@ -568,6 +570,7 @@ fn build_edges(
                     stmt.policy,
                     stmt.span,
                     /*is_feedback=*/ true,
+                    diags,
                 );
             }
 
@@ -628,6 +631,7 @@ fn build_edges(
                     stmt.policy,
                     stmt.span,
                     /*is_feedback=*/ false,
+                    diags,
                 );
 
                 // Edge 2: synth.output → dst  (feedback — breaks the cycle)
@@ -648,6 +652,7 @@ fn build_edges(
                     stmt.policy,
                     stmt.span,
                     /*is_feedback=*/ true,
+                    diags,
                 );
             }
         }
@@ -662,13 +667,24 @@ fn insert_edge(
     policy: ConnectionPolicy,
     span: proc_macro2::Span,
     is_feedback: bool,
+    diags: &mut Diagnostics,
 ) {
     // Compute primary source NodeId and extras from the IR source.
     let mut refs = collect_referenced_node_ids(&source);
     refs.dedup();
     let primary_src = match refs.first() {
         Some(&id) => id,
-        None => return, // Pure-literal source with no node references; skip.
+        None => {
+            // A source with no node references (e.g. `0.5 -> g.gain;`) has no
+            // edge to anchor on; silently dropping it would compile to a graph
+            // that never delivers the value.
+            diags.push_error(syn::Error::new(
+                span,
+                "constant connection sources are not supported; \
+                 set a default on the destination input instead",
+            ));
+            return;
+        }
     };
     let extra_sources: Vec<NodeId> = refs.into_iter().skip(1).collect();
 

--- a/oscen-graph-compiler/src/ir/lower.rs
+++ b/oscen-graph-compiler/src/ir/lower.rs
@@ -759,13 +759,24 @@ fn analyze_rates(ir: &mut IrGraph, diags: &mut Diagnostics) {
     let edge_ids: Vec<_> = ir.edges.keys().collect();
 
     for eid in edge_ids {
-        let (src_node_id, dst_node_id, policy, span) = {
+        let (src_node_id, dst_node_id, policy, span, src_index, dst_index) = {
             let edge = &ir.edges[eid];
             let src_node_id = match primary_node(&edge.source) {
                 Some(id) => id,
                 None => continue, // Pure-literal source; no rate to check.
             };
-            (src_node_id, edge.dest.node, edge.policy, edge.span)
+            let src_index = match &edge.source.kind {
+                IrExprKind::Endpoint(ep) => ep.index,
+                _ => None,
+            };
+            (
+                src_node_id,
+                edge.dest.node,
+                edge.policy,
+                edge.span,
+                src_index,
+                edge.dest.index,
+            )
         };
 
         let source_rate = ir.nodes[src_node_id].rate;
@@ -796,9 +807,13 @@ fn analyze_rates(ir: &mut IrGraph, diags: &mut Diagnostics) {
             }
         };
 
-        // Compute fanout shape from source/dest node array sizes.
-        let src_array_size = array_size_of(&ir.nodes[src_node_id].kind);
-        let dst_array_size = array_size_of(&ir.nodes[dst_node_id].kind);
+        // Compute fanout shape from source/dest node array sizes. An indexed
+        // endpoint (`voices[0].output`, `voices[2].frequency`) addresses one
+        // element, so it is scalar regardless of the node's array size.
+        let src_array_size =
+            array_size_of(&ir.nodes[src_node_id].kind).filter(|_| src_index.is_none());
+        let dst_array_size =
+            array_size_of(&ir.nodes[dst_node_id].kind).filter(|_| dst_index.is_none());
         let fanout = classify_fanout(src_array_size, dst_array_size);
 
         ir.edges[eid].kernel = kernel;

--- a/oscen-graph-compiler/src/ir/lower.rs
+++ b/oscen-graph-compiler/src/ir/lower.rs
@@ -732,8 +732,9 @@ impl crate::ir::expr::visit::Visitor for CollectEndpoints {
 /// Collect every `NodeId` referenced by an `IrExpr` source expression.
 /// Used by `build_edges` to anchor edges whose source is a compound
 /// expression — the first id is promoted to `IrEdge::source.node`, the
-/// rest are stored in `extra_source_nodes`.
-fn collect_referenced_node_ids(expr: &crate::ir::expr::IrExpr) -> Vec<NodeId> {
+/// rest are stored in `extra_source_nodes`. Also used by codegen's
+/// post-inner taint analysis to consider every referenced source node.
+pub(crate) fn collect_referenced_node_ids(expr: &crate::ir::expr::IrExpr) -> Vec<NodeId> {
     use crate::ir::expr::visit::Visitor;
     let mut v = CollectEndpoints::new();
     v.visit_expr(expr);

--- a/oscen-graph-compiler/src/ir/passes/dead_nodes.rs
+++ b/oscen-graph-compiler/src/ir/passes/dead_nodes.rs
@@ -22,8 +22,17 @@ pub fn run(ir: &mut IrGraph) {
     // edges; mark every node visited as live. Compound-source edges carry
     // additional referenced nodes in `extra_source_nodes` — walk those too
     // so e.g. `a.x * b.y -> out` keeps both `a` and `b` alive.
+    //
+    // Asset-bound nodes are also live roots: their external load handle is
+    // part of the graph's public API, and removing the node would leave its
+    // `AssetBinding` pointing at a freed key (codegen would panic).
     let mut live: HashSet<NodeId> = HashSet::new();
-    let mut queue: VecDeque<NodeId> = ir.outputs.iter().copied().collect();
+    let mut queue: VecDeque<NodeId> = ir
+        .outputs
+        .iter()
+        .copied()
+        .chain(ir.asset_bindings.iter().map(|b| b.node))
+        .collect();
     while let Some(id) = queue.pop_front() {
         if !live.insert(id) {
             continue;

--- a/oscen-graph-compiler/src/parse.rs
+++ b/oscen-graph-compiler/src/parse.rs
@@ -534,7 +534,10 @@ fn extract_array_and_embedded_rate(expr: Expr) -> Result<(Expr, Option<usize>, O
         {
             Some(c.base10_parse::<usize>()?)
         } else {
-            None
+            return Err(syn::Error::new_spanned(
+                &repeat.len,
+                "node array size must be an integer literal",
+            ));
         };
         Ok((*repeat.expr, count))
     }

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -69,3 +69,35 @@ fn literal_left_compound_source_keeps_node_alive() {
         "output assignment should read g.output"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Dead-node pass and asset bindings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn asset_bound_node_survives_dead_node_pass() {
+    // `player` has no path to a graph output; removing it used to leave the
+    // AssetBinding pointing at a freed key, panicking in codegen
+    // ("invalid SlotMap key used").
+    let tokens = compile_to_string(quote! {
+        name: AssetKeep;
+        input stream s;
+        output stream out;
+        external sample: AudioAsset;
+        node player = SamplePlayer::new();
+        node g = Gain::new(0.5);
+        connections {
+            sample -> player.buf;
+            s -> g.input;
+            g.output -> out;
+        }
+    });
+    assert!(
+        tokens.contains("pub player :"),
+        "asset-bound node `player` must stay alive"
+    );
+    assert!(
+        tokens.contains("pub sample :"),
+        "asset load handle field `sample` must be generated"
+    );
+}

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -101,3 +101,44 @@ fn asset_bound_node_survives_dead_node_pass() {
         "asset load handle field `sample` must be generated"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Ramped value inputs in compound expressions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ramped_input_in_compound_expression_reads_current() {
+    let tokens = compile_to_string(quote! {
+        name: RampCompound;
+        input stream s;
+        input value gain = 1.0 [ramp: 64];
+        output stream out;
+        node osc = Gain::new(0.5);
+        connections {
+            s -> osc.input;
+            osc.output * gain -> out;
+        }
+    });
+    assert!(
+        tokens.contains("self . osc . output * self . gain . current"),
+        "compound expression must read `.current` of the ramped input; got:\n{}",
+        tokens
+    );
+}
+
+#[test]
+fn bare_ramped_input_to_value_output_reads_current() {
+    let tokens = compile_to_string(quote! {
+        name: RampBare;
+        input value gain = 1.0 [ramp: 64];
+        output value level;
+        connections {
+            gain -> level;
+        }
+    });
+    assert!(
+        tokens.contains("self . level = self . gain . current"),
+        "bare ramped input forwarded to a value output must read `.current`; got:\n{}",
+        tokens
+    );
+}

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -1,0 +1,71 @@
+//! Regression tests for codegen correctness fixes. These compile a graph and
+//! assert on the generated token stream (or on a specific generated method's
+//! body, extracted via `syn`).
+
+use oscen_graph_compiler::compile;
+use quote::{quote, ToTokens};
+
+/// Compile a graph and return the generated tokens as a string.
+fn compile_to_string(tokens: proc_macro2::TokenStream) -> String {
+    match compile(tokens) {
+        Ok(ts) => ts.to_string(),
+        Err(diags) => panic!(
+            "compile failed: {:?}",
+            diags
+                .items
+                .iter()
+                .map(|d| d.message.to_string())
+                .collect::<Vec<_>>()
+        ),
+    }
+}
+
+/// Extract the body of an inherent method from the generated code.
+fn inherent_method_body(tokens: proc_macro2::TokenStream, method: &str) -> String {
+    let file: syn::File = syn::parse2(tokens).expect("generated code parses as a file");
+    for item in file.items {
+        if let syn::Item::Impl(imp) = item {
+            if imp.trait_.is_some() {
+                continue;
+            }
+            for it in imp.items {
+                if let syn::ImplItem::Fn(f) = it {
+                    if f.sig.ident == method {
+                        return f.block.to_token_stream().to_string();
+                    }
+                }
+            }
+        }
+    }
+    panic!("inherent method `{}` not found in generated code", method);
+}
+
+// ---------------------------------------------------------------------------
+// Literal-left compound source (`0.5 * g.output -> out`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn literal_left_compound_source_keeps_node_alive() {
+    // Used to panic in debug (IR validator) and silently prune `g` in
+    // release, because `primary_node` only descended the left operand.
+    let tokens = compile(quote! {
+        name: LitLeftCode;
+        input stream s;
+        output stream out;
+        node g = Gain::new(0.5);
+        connections {
+            s -> g.input;
+            0.5 * g.output -> out;
+        }
+    })
+    .expect("compile succeeds")
+    .to_string();
+    assert!(
+        tokens.contains("pub g :"),
+        "node `g` must not be pruned; got no `g` field"
+    );
+    assert!(
+        tokens.contains("self . g . output"),
+        "output assignment should read g.output"
+    );
+}

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -213,3 +213,55 @@ fn bare_event_passthrough_emits_queue_copy() {
         body
     );
 }
+
+// ---------------------------------------------------------------------------
+// Indexed endpoints on same-rate paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexed_source_and_dest_use_single_element_access() {
+    let tokens = compile_to_string(quote! {
+        name: IdxCode;
+        input stream s;
+        output stream out;
+        output stream solo;
+        node voices = [Gain::new(0.5); 3];
+        node fx = Gain::new(0.5);
+        node lfo = Gain::new(0.5);
+        connections {
+            s -> voices.input;
+            lfo.output -> voices[2].gain;
+            voices[0].output -> fx.input;
+            voices[1].output -> solo;
+            fx.output -> out;
+        }
+    });
+    // `voices[0].output -> fx.input` reads exactly one element (no fan-in sum).
+    assert!(
+        tokens.contains("self . voices [0usize] . output"),
+        "expected single-element read of voices[0]; got:\n{}",
+        tokens
+    );
+    assert!(
+        !tokens.contains("self . fx . input = self . voices . iter ()"),
+        "indexed source must not fan-in over the whole array:\n{}",
+        tokens
+    );
+    // `lfo.output -> voices[2].gain` writes exactly one element (no broadcast).
+    assert!(
+        tokens.contains("& mut self . voices [2usize] . gain"),
+        "expected single-element write to voices[2]; got:\n{}",
+        tokens
+    );
+    // `voices[1].output -> solo` (graph output) also reads one element.
+    assert!(
+        tokens.contains("self . voices [1usize] . output"),
+        "expected single-element read of voices[1] for graph output; got:\n{}",
+        tokens
+    );
+    assert!(
+        !tokens.contains("self . solo = self . voices . iter ()"),
+        "indexed graph-output source must not fan-in over the whole array:\n{}",
+        tokens
+    );
+}

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -142,3 +142,74 @@ fn bare_ramped_input_to_value_output_reads_current() {
         tokens
     );
 }
+
+// ---------------------------------------------------------------------------
+// Graph event outputs: cleared at cycle start, readable after process()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn event_output_is_not_cleared_after_population() {
+    let tokens = compile(quote! {
+        name: EvOut;
+        input event midi;
+        output event thru;
+        node seq = Sequencer::new();
+        connections {
+            midi -> seq.midi_in;
+            seq.midi_out -> thru;
+        }
+    })
+    .expect("compile succeeds");
+    let body = inherent_method_body(tokens, "process");
+
+    let clear_thru = "self . thru . clear ()";
+    let forward = "& mut self . thru";
+    let pos_forward = body
+        .find(forward)
+        .expect("process() should forward events into `thru`");
+    if let Some(pos_clear) = body.find(clear_thru) {
+        assert!(
+            pos_clear < pos_forward,
+            "event output must be cleared BEFORE it is populated:\n{}",
+            body
+        );
+    }
+    let after_forward = &body[pos_forward..];
+    assert!(
+        !after_forward.contains(clear_thru),
+        "event output must not be cleared after it is populated:\n{}",
+        body
+    );
+    // Event inputs are still cleared after processing.
+    let pos_clear_midi = body
+        .rfind("self . midi . clear ()")
+        .expect("event input should be cleared");
+    assert!(
+        pos_clear_midi > pos_forward,
+        "event input clearing should happen after processing:\n{}",
+        body
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bare event input -> event output passthrough (`midi -> thru`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_event_passthrough_emits_queue_copy() {
+    let tokens = compile(quote! {
+        name: EvThru;
+        input event midi;
+        output event thru;
+        connections {
+            midi -> thru;
+        }
+    })
+    .expect("compile succeeds");
+    let body = inherent_method_body(tokens, "process");
+    assert!(
+        body.contains("(& self . midi , & mut self . thru)"),
+        "expected a queue copy from `midi` to `thru`; got:\n{}",
+        body
+    );
+}

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -265,3 +265,79 @@ fn indexed_source_and_dest_use_single_element_access() {
         tokens
     );
 }
+
+// ---------------------------------------------------------------------------
+// Post-inner taint propagation (multirate scheduling)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_source_taints_post_inner_consumer() {
+    // `d` consumes a Down edge (post-inner). `a.output + d.output -> mix.input`
+    // must schedule `mix` post-inner even though the leftmost operand is the
+    // untainted `a`.
+    let tokens = compile(quote! {
+        name: TaintCompound;
+        input stream s;
+        output stream out;
+        node up = Gain::new(0.5) * 2;
+        node a = Gain::new(0.5);
+        node d = Gain::new(0.5);
+        node mix = Gain::new(0.5);
+        connections {
+            s -> up.input;
+            s -> a.input;
+            up.output -> d.input;
+            a.output + d.output -> mix.input;
+            mix.output -> out;
+        }
+    })
+    .expect("compile succeeds");
+    let body = inherent_method_body(tokens, "process");
+    let pos_d = body
+        .find("self . d . process ()")
+        .expect("d should be processed");
+    let pos_mix = body
+        .find("self . mix . process ()")
+        .expect("mix should be processed");
+    assert!(
+        pos_mix > pos_d,
+        "mix consumes tainted d and must run post-inner (after d):\n{}",
+        body
+    );
+}
+
+#[test]
+fn same_rate_event_edge_propagates_post_inner_taint() {
+    // `d` is post-inner; the same-rate event edge `d.midi_out -> sink.midi_in`
+    // must pull `sink` post-inner too (its events would otherwise be a frame
+    // stale).
+    let tokens = compile(quote! {
+        name: TaintEvent;
+        input stream s;
+        input event midi;
+        output stream out;
+        node up = Gain::new(0.5) * 2;
+        node d = Gain::new(0.5);
+        node sink = Gain::new(0.5);
+        connections {
+            s -> up.input;
+            up.output -> d.input;
+            midi -> sink.midi_in;
+            d.midi_out -> sink.midi_in;
+            sink.output -> out;
+        }
+    })
+    .expect("compile succeeds");
+    let body = inherent_method_body(tokens, "process");
+    let pos_d = body
+        .find("self . d . process ()")
+        .expect("d should be processed");
+    let pos_sink = body
+        .find("self . sink . process ()")
+        .expect("sink should be processed");
+    assert!(
+        pos_sink > pos_d,
+        "sink consumes a same-rate event edge from tainted d and must run post-inner:\n{}",
+        body
+    );
+}

--- a/oscen-graph-compiler/tests/codegen_regressions.rs
+++ b/oscen-graph-compiler/tests/codegen_regressions.rs
@@ -341,3 +341,26 @@ fn same_rate_event_edge_propagates_post_inner_taint() {
         body
     );
 }
+
+// ---------------------------------------------------------------------------
+// set_X_with_ramp(value, 0) must not leak the active_ramps counter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zero_frame_ramp_setter_decrements_active_ramps() {
+    let tokens = compile(quote! {
+        name: RampZero;
+        input value gain = 1.0 [ramp: 64];
+        output value level;
+        connections {
+            gain -> level;
+        }
+    })
+    .expect("compile succeeds");
+    let body = inherent_method_body(tokens, "set_gain_with_ramp");
+    assert!(
+        body.contains("self . active_ramps -= 1"),
+        "frames == 0 with an in-flight ramp must decrement active_ramps; got:\n{}",
+        body
+    );
+}

--- a/oscen-graph-compiler/tests/lower.rs
+++ b/oscen-graph-compiler/tests/lower.rs
@@ -630,3 +630,32 @@ fn plain_arrow_cycle_diagnostic_mentions_bracket_syntax() {
         msgs
     );
 }
+
+#[test]
+fn mixed_oversampling_factors_are_rejected() {
+    // Two disjoint oversampled chains with different `* N` factors used to
+    // compile and panic (index out of bounds) on the first process_block:
+    // the inner loop runs to the max factor while each edge buffer is sized
+    // by its own factor.
+    let (ir, diags) = lower_quote(quote! {
+        name: MixedUp;
+        input stream s;
+        output stream out_a;
+        output stream out_b;
+        node a = Gain::new(0.5) * 2;
+        node b = Gain::new(0.5) * 4;
+        connections {
+            s -> a.input;
+            s -> b.input;
+            a.output -> out_a;
+            b.output -> out_b;
+        }
+    });
+    assert!(ir.is_none(), "lower should reject mixed `* N` factors");
+    let msgs: Vec<String> = diags.items.iter().map(|d| d.message.to_string()).collect();
+    assert!(
+        msgs.iter().any(|m| m.contains("same rate factor")),
+        "expected mixed-factor error; got: {:?}",
+        msgs
+    );
+}

--- a/oscen-graph-compiler/tests/lower.rs
+++ b/oscen-graph-compiler/tests/lower.rs
@@ -659,3 +659,27 @@ fn mixed_oversampling_factors_are_rejected() {
         msgs
     );
 }
+
+#[test]
+fn constant_connection_source_is_rejected() {
+    // `0.5 -> g.gain;` used to be silently dropped (no edge, no diagnostic).
+    let (ir, diags) = lower_quote(quote! {
+        name: ConstSrc;
+        input stream s;
+        output stream out;
+        node g = Gain::new(0.5);
+        connections {
+            s -> g.input;
+            0.5 -> g.gain;
+            g.output -> out;
+        }
+    });
+    assert!(ir.is_none(), "lower should reject a constant-only source");
+    let msgs: Vec<String> = diags.items.iter().map(|d| d.message.to_string()).collect();
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("constant connection sources are not supported")),
+        "expected constant-source error; got: {:?}",
+        msgs
+    );
+}

--- a/oscen-graph-compiler/tests/lower.rs
+++ b/oscen-graph-compiler/tests/lower.rs
@@ -726,3 +726,27 @@ fn literal_left_compound_source_anchors_on_endpoint() {
         .any(|&eid| ir.edges[eid].dest.node == out_id);
     assert!(anchored, "compound edge should be anchored on `g`");
 }
+
+#[test]
+fn non_literal_node_array_size_is_rejected() {
+    // `[Voice::new(); NUM_VOICES]` used to silently lower to a single
+    // (scalar) node when the length was not an integer literal.
+    let (ir, diags) = lower_quote(quote! {
+        name: NamedLen;
+        input stream s;
+        output stream out;
+        node voices = [Gain::new(0.5); NUM_VOICES];
+        connections {
+            s -> voices.input;
+            voices.output -> out;
+        }
+    });
+    assert!(ir.is_none(), "non-literal array size should be an error");
+    let msgs: Vec<String> = diags.items.iter().map(|d| d.message.to_string()).collect();
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("node array size must be an integer literal")),
+        "expected array-size error; got: {:?}",
+        msgs
+    );
+}

--- a/oscen-graph-compiler/tests/lower.rs
+++ b/oscen-graph-compiler/tests/lower.rs
@@ -750,3 +750,54 @@ fn non_literal_node_array_size_is_rejected() {
         msgs
     );
 }
+
+#[test]
+fn indexed_endpoints_classify_as_scalar_fanout() {
+    // `voices[0].output -> fx.input` addresses one element; it must not be
+    // classified as an array fan-in (and an indexed destination must not be
+    // classified as a broadcast).
+    let (ir, diags) = lower_quote(quote! {
+        name: Idx;
+        input stream s;
+        output stream out;
+        node voices = [Gain::new(0.5); 3];
+        node fx = Gain::new(0.5);
+        node lfo = Gain::new(0.5);
+        connections {
+            s -> voices.input;
+            lfo.output -> voices[2].gain;
+            voices[0].output -> fx.input;
+            fx.output -> out;
+        }
+    });
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {:?}",
+        diags.items
+    );
+    let ir = ir.expect("lower should produce an IrGraph");
+
+    use oscen_graph_compiler::ir::FanoutShape;
+    for edge in ir.edges.values() {
+        let dest_name = ir.nodes[edge.dest.node].name.to_string();
+        let src_index = match &edge.source.kind {
+            oscen_graph_compiler::ir::IrExprKind::Endpoint(ep) => ep.index,
+            _ => None,
+        };
+        if src_index.is_some() || edge.dest.index.is_some() {
+            assert!(
+                matches!(edge.fanout, FanoutShape::Scalar),
+                "indexed edge into `{}` should be Scalar, got {:?}",
+                dest_name,
+                edge.fanout
+            );
+        }
+        if dest_name == "voices" && edge.dest.index.is_none() {
+            assert!(
+                matches!(edge.fanout, FanoutShape::Broadcast { n: 3 }),
+                "un-indexed edge into `voices` should stay Broadcast, got {:?}",
+                edge.fanout
+            );
+        }
+    }
+}

--- a/oscen-graph-compiler/tests/lower.rs
+++ b/oscen-graph-compiler/tests/lower.rs
@@ -683,3 +683,46 @@ fn constant_connection_source_is_rejected() {
         msgs
     );
 }
+
+#[test]
+fn literal_left_compound_source_anchors_on_endpoint() {
+    // `0.5 * g.output -> out` anchors the edge on `g` even though the
+    // literal is the left operand. This used to panic in the debug IR
+    // validator (edge source not matching `primary_node`) and silently
+    // prune `g` in release builds.
+    let (ir, diags) = lower_quote(quote! {
+        name: LitLeft;
+        input stream s;
+        output stream out;
+        node g = Gain::new(0.5);
+        connections {
+            s -> g.input;
+            0.5 * g.output -> out;
+        }
+    });
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {:?}",
+        diags.items
+    );
+    let ir = ir.expect("lower should produce an IrGraph");
+
+    let g_id = ir
+        .nodes
+        .iter()
+        .find(|(_, n)| n.name == "g")
+        .map(|(id, _)| id)
+        .expect("node g");
+    let out_id = ir
+        .outputs
+        .iter()
+        .copied()
+        .find(|&id| ir.nodes[id].name == "out")
+        .expect("output out");
+    // The compound edge into `out` must appear in g's outgoing list.
+    let anchored = ir.nodes[g_id]
+        .outgoing
+        .iter()
+        .any(|&eid| ir.edges[eid].dest.node == out_id);
+    assert!(anchored, "compound edge should be anchored on `g`");
+}

--- a/oscen-macros/tests/ui/mixed_rates.stderr
+++ b/oscen-macros/tests/ui/mixed_rates.stderr
@@ -1,3 +1,9 @@
+error: all oversampled nodes in a graph must use the same rate factor (found `* 4` and `* 2`); use the highest factor for every oversampled node
+ --> tests/ui/mixed_rates.rs:8:9
+  |
+8 |         b = TptFilter::new(1000.0, 0.7) * 2;
+  |         ^
+
 error: v1 does not support connections between two differently-rated non-default-rate nodes; route through an outer-rate node instead
   --> tests/ui/mixed_rates.rs:11:9
    |


### PR DESCRIPTION
Fixes ten confirmed code-review findings in oscen-graph-compiler, each with a regression test verified to fail against the unfixed code:

- Reject mixed oversampling factors during lowering with a diagnostic (previously compiled cleanly and panicked out-of-bounds on the first process_block); the clock-division upgrade path is documented at the rejection site
- Anchor compound connection sources on the first endpoint anywhere in the expression — `0.5 * g.output -> out` previously panicked the debug validator and silently pruned the node in release
- Report constant connection sources (`0.5 -> g.gain`) as errors instead of silently dropping the edge
- Keep asset-bound nodes alive in the dead-node pass (stale AssetBinding previously panicked codegen)
- Require node array sizes to be integer literals (`[Voice::new(); NUM_VOICES]` previously lowered to a single node)
- Clear graph event outputs at cycle start instead of after they are populated, so hosts and nested graphs can read them
- Route indexed endpoints (`voices[0].output`, `voices[2].frequency`) as single-element connections instead of whole-array fan-in/broadcast
- Emit `.current` for ramped value inputs referenced from compound expressions and direct output assignments (previously generated non-compiling code)
- Propagate post-inner taint through compound sources and same-rate event edges (previously produced one-frame-stale reads, dependent on operand order)
- Forward bare graph event inputs to graph event outputs (`midi -> thru` previously emitted no code)
- Fix active_ramps counter leak when a zero-frame ramp interrupts a running ramp

15 new regression tests (5 in tests/lower.rs, 10 in tests/codegen_regressions.rs). Full workspace test suite passes; the crate is clippy-clean.