### PR TITLE
Clamp filter cutoffs below Nyquist and flush TPT denormals

### DIFF
--- a/oscen-lib/src/filters/iir_lowpass/mod.rs
+++ b/oscen-lib/src/filters/iir_lowpass/mod.rs
@@ -82,8 +82,10 @@ impl IirLowpass {
     /// 2. Calculate coefficients in the analog domain
     /// 3. Apply bilinear transform to get digital coefficients
     fn update_coefficients(&mut self, sample_rate: f32) {
-        let nyquist = sample_rate * 0.5 - f32::EPSILON;
-        let freq = self.cutoff.clamp(20.0, nyquist);
+        // Keep the cutoff strictly below Nyquist with a relative margin: an
+        // absolute epsilon rounds away at these magnitudes, letting tan() blow
+        // up and push the poles onto the unit circle.
+        let freq = self.cutoff.clamp(20.0, sample_rate * 0.49);
         let q = self.q.max(0.01); // Prevent division by zero
 
         // Pre-warping: n = 1/tan(π·f/fs)
@@ -307,6 +309,103 @@ mod tests {
                 filter.output.abs() < 10.0,
                 "Output unstable at sample {}: {}",
                 n,
+                filter.output
+            );
+        }
+    }
+
+    /// Deterministic white-ish noise in [-1, 1) from a seeded LCG.
+    fn lcg_noise(seed: &mut u32) -> f32 {
+        *seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        (*seed >> 8) as f32 / (1 << 24) as f32 * 2.0 - 1.0
+    }
+
+    #[test]
+    fn test_coefficients_stable_at_and_beyond_nyquist() {
+        // Cutoffs at or above Nyquist must still produce poles strictly inside
+        // the unit circle (biquad stability triangle: |a2| < 1, |a1| < 1 + a2).
+        for &sample_rate in &[22_050.0, 32_000.0, 44_100.0, 48_000.0, 96_000.0] {
+            for &cutoff in &[sample_rate * 0.5, sample_rate, 1e6] {
+                let mut filter = IirLowpass::new(cutoff, std::f32::consts::FRAC_1_SQRT_2);
+                filter.set_sample_rate(sample_rate);
+                filter.prepare();
+
+                assert!(
+                    filter.a2.abs() < 1.0,
+                    "pole on/outside unit circle at sr={}, cutoff={}: a2={}",
+                    sample_rate,
+                    cutoff,
+                    filter.a2
+                );
+                assert!(
+                    filter.a1.abs() < 1.0 + filter.a2,
+                    "unstable coefficients at sr={}, cutoff={}: a1={}, a2={}",
+                    sample_rate,
+                    cutoff,
+                    filter.a1,
+                    filter.a2
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_output_finite_and_bounded_across_extremes() {
+        let sample_rates = [22_050.0, 32_000.0, 44_100.0, 48_000.0, 96_000.0];
+        let qs = [0.01, std::f32::consts::FRAC_1_SQRT_2, 10.0];
+        for &sample_rate in &sample_rates {
+            let cutoffs = [
+                20.0,
+                1_000.0,
+                sample_rate * 0.25,
+                sample_rate * 0.49,
+                sample_rate * 0.5,
+                sample_rate,
+                100_000.0,
+            ];
+            for &cutoff in &cutoffs {
+                for &q in &qs {
+                    let mut filter = IirLowpass::new(cutoff, q);
+                    filter.set_sample_rate(sample_rate);
+                    filter.prepare();
+
+                    let mut seed = 0x1234_5678_u32;
+                    for n in 0..8_000 {
+                        filter.input = lcg_noise(&mut seed);
+                        filter.process();
+                        assert!(
+                            filter.output.is_finite() && filter.output.abs() < 100.0,
+                            "unstable output at sr={}, cutoff={}, q={}, sample {}: {}",
+                            sample_rate,
+                            cutoff,
+                            q,
+                            n,
+                            filter.output
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_dc_gain_unity_across_sample_rates() {
+        use float_cmp::approx_eq;
+
+        for &sample_rate in &[22_050.0, 32_000.0, 44_100.0, 48_000.0, 96_000.0] {
+            let mut filter = IirLowpass::new(1_000.0, std::f32::consts::FRAC_1_SQRT_2);
+            filter.set_sample_rate(sample_rate);
+            filter.prepare();
+
+            for _ in 0..4_000 {
+                filter.input = 1.0;
+                filter.process();
+            }
+
+            assert!(
+                approx_eq!(f32, filter.output, 1.0, epsilon = 0.01),
+                "DC gain should be ~1.0 at sr={}: got {}",
+                sample_rate,
                 filter.output
             );
         }

--- a/oscen-lib/src/filters/tpt/mod.rs
+++ b/oscen-lib/src/filters/tpt/mod.rs
@@ -67,8 +67,10 @@ impl<F: AudioFrame> TptFilter<F> {
     }
 
     fn update_coefficients(&mut self, sample_rate: f32, cutoff: f32, q: f32) {
-        let nyquist = sample_rate * 0.5 - f32::EPSILON;
-        let freq = cutoff.clamp(20.0, nyquist);
+        // Keep the cutoff strictly below Nyquist with a relative margin: an
+        // absolute epsilon rounds away at these magnitudes, letting tan() blow
+        // up and degenerate the coefficients.
+        let freq = cutoff.clamp(20.0, sample_rate * 0.49);
         let period = 0.5 / sample_rate;
         let f = (2.0 * sample_rate) * (2.0 * PI * freq * period).tan() * period;
         let inv_q = 1.0 / q;
@@ -83,8 +85,7 @@ impl<F: AudioFrame> TptFilter<F> {
 
     #[inline(always)]
     fn apply_parameter_updates(&mut self, sample_rate: f32) {
-        let nyquist = sample_rate * 0.5 - f32::EPSILON;
-        let max_cutoff = nyquist.min(20_000.0);
+        let max_cutoff = (sample_rate * 0.49).min(20_000.0);
         let cutoff_base = self.cutoff.clamp(20.0, max_cutoff);
         let q = self.q.clamp(0.1, 10.0);
 
@@ -193,6 +194,82 @@ mod tests {
                 "channel 1 should stay silent at sample {}: got {}",
                 n,
                 filter.output.0[1]
+            );
+        }
+    }
+
+    /// Deterministic white-ish noise in [-1, 1) from a seeded LCG.
+    fn lcg_noise(seed: &mut u32) -> f32 {
+        *seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        (*seed >> 8) as f32 / (1 << 24) as f32 * 2.0 - 1.0
+    }
+
+    #[test]
+    fn test_output_finite_and_bounded_across_extremes() {
+        let sample_rates = [22_050.0, 32_000.0, 44_100.0, 48_000.0, 96_000.0];
+        let qs = [0.1, 0.707, 10.0];
+        for &sample_rate in &sample_rates {
+            let cutoffs = [
+                20.0,
+                1_000.0,
+                sample_rate * 0.25,
+                sample_rate * 0.49,
+                sample_rate * 0.5,
+                sample_rate,
+                100_000.0,
+            ];
+            for &cutoff in &cutoffs {
+                for &q in &qs {
+                    let mut filter = TptFilter::<f32>::new(cutoff, q);
+                    filter.set_sample_rate(sample_rate);
+                    filter.prepare();
+                    filter.cutoff = cutoff;
+                    filter.q = q;
+                    filter.f_mod = 0.0;
+
+                    // The degenerate-coefficient blow-up is a slow exponential,
+                    // so drive the filter long enough to expose it.
+                    let mut seed = 0x1234_5678_u32;
+                    for n in 0..100_000 {
+                        filter.input = lcg_noise(&mut seed);
+                        filter.process();
+                        assert!(
+                            filter.output.is_finite() && filter.output.abs() < 100.0,
+                            "unstable output at sr={}, cutoff={}, q={}, sample {}: {}",
+                            sample_rate,
+                            cutoff,
+                            q,
+                            n,
+                            filter.output
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_dc_gain_unity_across_sample_rates() {
+        use float_cmp::approx_eq;
+
+        for &sample_rate in &[22_050.0, 32_000.0, 44_100.0, 48_000.0, 96_000.0] {
+            let mut filter = TptFilter::<f32>::new(1_000.0, 0.707);
+            filter.set_sample_rate(sample_rate);
+            filter.prepare();
+            filter.cutoff = 1_000.0;
+            filter.q = 0.707;
+            filter.f_mod = 0.0;
+
+            for _ in 0..4_000 {
+                filter.input = 1.0;
+                filter.process();
+            }
+
+            assert!(
+                approx_eq!(f32, filter.output, 1.0, epsilon = 0.01),
+                "DC gain should be ~1.0 at sr={}: got {}",
+                sample_rate,
+                filter.output
             );
         }
     }

--- a/oscen-lib/src/filters/tpt/mod.rs
+++ b/oscen-lib/src/filters/tpt/mod.rs
@@ -116,8 +116,10 @@ impl<F: AudioFrame> TptFilter<F> {
         let band = high * self.g + self.z[0];
         let low = band * self.g + self.z[1];
 
-        self.z[0] = high * self.g + band;
-        self.z[1] = band * self.g + low;
+        // Flush the feedback state to zero before it decays into subnormals,
+        // which are 10-100x slower on hardware without flush-to-zero.
+        self.z[0] = (high * self.g + band).flush_denormal(1e-30);
+        self.z[1] = (band * self.g + low).flush_denormal(1e-30);
 
         // Write output
         self.output = low;
@@ -272,6 +274,37 @@ mod tests {
                 filter.output
             );
         }
+    }
+
+    /// After the input goes silent the integrator state must be flushed to
+    /// zero before it decays into the f32 subnormal range, where multiplies
+    /// are 10-100x slower on hardware without flush-to-zero.
+    #[test]
+    fn test_integrator_state_never_goes_subnormal_after_silence() {
+        let mut filter = TptFilter::<f32>::new(1_000.0, 0.707);
+        filter.set_sample_rate(48_000.0);
+        filter.prepare();
+        filter.cutoff = 1_000.0;
+        filter.q = 0.707;
+        filter.f_mod = 0.0;
+
+        filter.input = 1.0;
+        filter.process();
+
+        filter.input = 0.0;
+        for n in 0..20_000 {
+            filter.process();
+            for (i, &z) in filter.z.iter().enumerate() {
+                assert!(
+                    z == 0.0 || z.is_normal(),
+                    "integrator state z[{}] is subnormal at sample {}: {:e}",
+                    i,
+                    n,
+                    z
+                );
+            }
+        }
+        assert_eq!(filter.z, [0.0, 0.0], "state should settle to exactly zero");
     }
 
     #[test]


### PR DESCRIPTION
Fixes three confirmed review findings in oscen-lib/src/filters/:

- IirLowpass: the Nyquist guard `sample_rate * 0.5 - f32::EPSILON` was a no-op (the epsilon rounds away at these magnitudes), so cutoff could clamp to exactly Nyquist, where tan() degenerates the coefficients and puts a repeated pole on/outside the unit circle. Replaced with a relative margin (`sample_rate * 0.49`).
- TptFilter: same no-op epsilon; the 20 kHz cap masked it at common rates but at sample rates below 40 kHz (e.g. 32 kHz, 22.05 kHz) cutoff reached exact Nyquist. Reproduced pre-fix: output grows exponentially to ~1e18 at sr=32kHz, cutoff=16kHz, q=0.1. Same relative margin applied in both the parameter path and prepare path.
- TptFilter: the z[0]/z[1] integrator state had no denormal protection (the sibling IirLowpass and the halfband IIR both flush). Now flushed with the existing AudioFrame::flush_denormal; pre-fix the state went subnormal at sample 887 after silence.

New property tests for both filters: finiteness/boundedness sweep across cutoff (20 Hz to beyond Nyquist) x Q extremes x five sample rates with seeded-LCG noise, DC-gain-unity checks, coefficient stability-triangle assertions, and a subnormal-state regression test. The pinned TPT impulse-response test passes unchanged.