### PR TITLE
Fix ADSR mid-stage retiming snap and oscillator negative-frequency underflow

### DIFF
--- a/oscen-lib/src/envelope/adsr.rs
+++ b/oscen-lib/src/envelope/adsr.rs
@@ -91,18 +91,27 @@ impl AdsrEnvelope {
 
     fn update_sustain_level(&mut self) {
         self.sustain_level = (self.sustain * self.velocity).clamp(0.0, 1.0);
+        let old_attack_samples = self.attack_samples;
+        let old_decay_samples = self.decay_samples;
+        let old_release_samples = self.release_samples;
         self.recalculate_cached_steps();
-        match self.stage {
+        // If the active stage's total length changed, rescale the remaining
+        // sample count so the stage keeps its fractional progress. The cached
+        // coefficients are derived from the new total, so keeping the old
+        // remaining count would end the stage far from its target and snap.
+        let (old_total, new_total) = match self.stage {
             Stage::Attack if self.samples_remaining > 0 => {
-                self.samples_remaining = self.samples_remaining.min(self.attack_samples).max(1);
+                (old_attack_samples, self.attack_samples)
             }
-            Stage::Decay if self.samples_remaining > 0 => {
-                self.samples_remaining = self.samples_remaining.min(self.decay_samples).max(1);
-            }
+            Stage::Decay if self.samples_remaining > 0 => (old_decay_samples, self.decay_samples),
             Stage::Release if self.samples_remaining > 0 => {
-                self.samples_remaining = self.samples_remaining.min(self.release_samples).max(1);
+                (old_release_samples, self.release_samples)
             }
-            _ => {}
+            _ => (0, 0),
+        };
+        if old_total > 0 && old_total != new_total {
+            let rescaled = new_total as u64 * self.samples_remaining as u64 / old_total as u64;
+            self.samples_remaining = (rescaled as u32).max(1);
         }
         match self.stage {
             Stage::Decay | Stage::Sustain => self.target_level = self.sustain_level,
@@ -360,6 +369,41 @@ mod tests {
         }
 
         assert!(env.output <= 0.01, "value {} not near zero", env.output);
+    }
+
+    #[test]
+    fn lengthening_attack_mid_stage_does_not_snap() {
+        let mut env = AdsrEnvelope::new(0.01, 0.02, 0.6, 0.05);
+        env.set_sample_rate(48_000.0);
+        env.prepare();
+
+        env.handle_gate_event(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::scalar(1.0),
+        });
+
+        // 100 samples into the 0.01 s attack, lengthen it to 1.0 s.
+        for _ in 0..100 {
+            env.process();
+        }
+        env.attack = 1.0;
+
+        // Run through the rest of the attack and into the decay; the largest
+        // single-sample step must stay small (no amplitude snap). The one-pole
+        // curve lands 99% of the way to its target before snapping, so the
+        // stage-end correction is at most ~0.01.
+        let mut previous = env.output;
+        let mut max_step = 0.0f32;
+        for _ in 0..96_000 {
+            env.process();
+            max_step = max_step.max((env.output - previous).abs());
+            previous = env.output;
+        }
+
+        assert!(
+            max_step < 0.011,
+            "attack change caused amplitude snap of {max_step}"
+        );
     }
 
     #[test]

--- a/oscen-lib/src/envelope/adsr.rs
+++ b/oscen-lib/src/envelope/adsr.rs
@@ -318,6 +318,40 @@ impl AdsrEnvelope {
 mod tests {
     use super::*;
     use crate::graph::types::EventPayload;
+    use float_cmp::approx_eq;
+
+    #[test]
+    fn attack_reaches_target_on_schedule() {
+        let sample_rate = 48_000.0;
+        let attack_seconds = 0.05;
+        let mut env = AdsrEnvelope::new(attack_seconds, 0.1, 0.5, 0.05);
+        env.set_sample_rate(sample_rate);
+        env.prepare();
+
+        env.handle_gate_event(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::scalar(1.0),
+        });
+
+        // The one-pole coefficient is derived so the level is 99% of the way
+        // to the target on the last attack sample, where it snaps to 1.0.
+        let attack_samples = (attack_seconds * sample_rate) as u32;
+        for _ in 0..attack_samples - 1 {
+            env.process();
+        }
+        assert!(
+            approx_eq!(f32, env.output, 0.99, epsilon = 0.001),
+            "level {} not ~99% of target one sample before attack end",
+            env.output
+        );
+
+        env.process();
+        assert!(
+            approx_eq!(f32, env.output, 1.0, ulps = 2),
+            "level {} did not reach target at attack end",
+            env.output
+        );
+    }
 
     #[test]
     fn reaches_sustain_level() {

--- a/oscen-lib/src/oscillators/mod.rs
+++ b/oscen-lib/src/oscillators/mod.rs
@@ -64,11 +64,10 @@ impl Oscillator {
 impl SignalProcessor for Oscillator {
     #[inline(always)]
     fn process(&mut self) {
-        let frequency = self.frequency * (1.0 + self.frequency_mod);
+        let frequency = (self.frequency * (1.0 + self.frequency_mod)).max(0.0);
         let amplitude = self.amplitude;
 
-        let modulated_phase = self.phase % 1.0;
-        self.output = (self.waveform)(modulated_phase) * amplitude;
+        self.output = (self.waveform)(self.phase) * amplitude;
 
         self.phase += frequency / *self.sample_rate;
         self.phase %= 1.0;
@@ -179,16 +178,12 @@ impl SignalProcessor for PolyBlepOscillator {
         // Calculate modulated frequency
         let frequency = (self.frequency * (1.0 + self.frequency_mod)).max(0.0);
         let amplitude = self.amplitude;
-        let mut pulse_width = self.pulse_width.clamp(0.0001, 0.9999);
+        let pulse_width = self.pulse_width.clamp(0.0001, 0.9999);
 
         // Calculate phase with modulation
         let mut phase = Self::wrap_phase(self.phase + self.phase_mod);
         let freq_per_sample = frequency / self.sample_rate.max(f32::EPSILON);
         let dt = freq_per_sample.min(1.0);
-
-        if pulse_width <= 0.0 {
-            pulse_width = 0.0001;
-        }
 
         // Generate waveform with PolyBLEP anti-aliasing
         let mut value = if frequency >= *self.sample_rate * 0.25 {
@@ -234,7 +229,44 @@ impl SignalProcessor for PolyBlepOscillator {
 
 #[cfg(test)]
 mod tests {
-    use super::{PolyBlepOscillator, PolyBlepWaveform, SignalProcessor};
+    use super::{Oscillator, PolyBlepOscillator, PolyBlepWaveform, SignalProcessor};
+
+    #[test]
+    fn test_oscillator_clamps_negative_modulated_frequency() {
+        let sample_rate = 48_000.0;
+        let mut saw = Oscillator::saw(440.0, 1.0);
+        saw.set_sample_rate(sample_rate);
+        let mut square = Oscillator::square(440.0, 1.0);
+        square.set_sample_rate(sample_rate);
+
+        let mut saw_min = f32::MAX;
+        let mut saw_max = f32::MIN;
+        let mut square_high = false;
+        let mut square_low = false;
+
+        // FM depth 2: alternate blocks where the modulated frequency is
+        // negative (must clamp to zero) and blocks of plain playback.
+        for i in 0..2_000 {
+            let mod_value = if (i / 100) % 2 == 0 { -2.0 } else { 0.0 };
+            saw.frequency_mod = mod_value;
+            square.frequency_mod = mod_value;
+            saw.process();
+            square.process();
+            saw_min = saw_min.min(saw.output);
+            saw_max = saw_max.max(saw.output);
+            square_high |= square.output > 0.5;
+            square_low |= square.output < -0.5;
+        }
+
+        assert!(
+            saw_min >= -1.0 && saw_max <= 1.0,
+            "saw output out of bounds: min {saw_min}, max {saw_max}"
+        );
+        assert!(
+            square_high && square_low,
+            "square stopped alternating under negative frequency modulation"
+        );
+    }
 
     #[test]
     fn test_poly_blep_saw_stays_bounded() {

--- a/oscen-lib/src/oscillators/mod.rs
+++ b/oscen-lib/src/oscillators/mod.rs
@@ -269,6 +269,32 @@ mod tests {
     }
 
     #[test]
+    fn test_poly_blep_frequency_accuracy() {
+        let sample_rate = 48_000.0;
+        let mut osc = PolyBlepOscillator::sine(440.0, 1.0);
+        osc.set_sample_rate(sample_rate);
+        osc.phase_mod = 0.0;
+        osc.frequency_mod = 0.0;
+
+        // Count rising zero-crossings over exactly one second: there should
+        // be one per cycle, so approximately 440.
+        let mut crossings = 0i32;
+        let mut previous = 0.0f32;
+        for i in 0..(sample_rate as usize) {
+            osc.process();
+            if i > 0 && previous < 0.0 && osc.output >= 0.0 {
+                crossings += 1;
+            }
+            previous = osc.output;
+        }
+
+        assert!(
+            (crossings - 440).abs() <= 1,
+            "expected ~440 rising zero-crossings, got {crossings}"
+        );
+    }
+
+    #[test]
     fn test_poly_blep_saw_stays_bounded() {
         let sample_rate = 48_000.0;
         let mut osc = PolyBlepOscillator::saw(440.0, 1.0);


### PR DESCRIPTION
Fixes two confirmed review findings:

- AdsrEnvelope: lengthening attack/decay while the stage was in flight kept the old (short) samples_remaining while recomputing the one-pole coefficient for the new length, so the stage ended far from its target and snapped (measured 0.37 full-scale single-sample step). The remaining count is now rescaled proportionally so the stage keeps its fractional progress.
- Oscillator (naive): modulated frequency was unclamped, so FM depth > 1 drove the phase negative through the truncated % operator — square became constant DC and saw emitted samples down to -3x amplitude. Now clamped non-negative, matching PolyBlepOscillator. Also removed a redundant phase re-wrap and a dead pulse-width branch.

New tests: mid-attack retiming regression (fails pre-fix with the 0.37 snap), negative-FM bounds/alternation regression (fails pre-fix at saw min -2.83), PolyBLEP 440 Hz zero-crossing frequency accuracy, and ADSR attack timing pinned to the implementation's actual 99%-then-snap contract.

Velocity handling is deliberately untouched — the velocity/attack-peak issue is addressed separately with a configurable-sensitivity design.