### PR TITLE
Fix ring buffer boundary bleed, delay sizing, and convolution IR swap click

### DIFF
--- a/oscen-lib/src/convolution/mod.rs
+++ b/oscen-lib/src/convolution/mod.rs
@@ -459,6 +459,10 @@ pub struct Convolver<F: AudioFrame = f32> {
 
     current: Arc<MultiConvolverEngine>,
     fading: Option<(Arc<MultiConvolverEngine>, usize)>,
+    /// Engine published while a crossfade was already in progress; promoted
+    /// into a new fade when the active fade completes (newest wins — a
+    /// displaced pending engine is retired for off-thread destruction).
+    pending: Option<Arc<MultiConvolverEngine>>,
     fade_len: usize,
     #[input(asset)]
     pub ir: AssetSlot<MultiConvolverEngine>,
@@ -477,6 +481,7 @@ impl<F: AudioFrame> Convolver<F> {
             output: F::default(),
             current: Arc::new(MultiConvolverEngine::from_mono_ir(&[], F::CHANNELS)),
             fading: None,
+            pending: None,
             fade_len: 1,
             ir: AssetSlot::new(),
             sample_rate: SampleRate::default(),
@@ -529,20 +534,25 @@ impl<F: AudioFrame> SignalProcessor for Convolver<F> {
             .expect("engine uniquely owned at prepare")
             .rebuild();
         self.fading = None;
+        self.pending = None;
     }
 
     #[inline]
     fn process(&mut self) {
         // 1. Pull a newly published engine, if any (RT-safe: atomic swap).
         if let Some(new_engine) = self.ir.take() {
-            if let Some((old, _)) = self.fading.take() {
-                // A second swap landed mid-fade: retire the in-progress
-                // outgoing engine now (keeps at most two engines live), fade
-                // from the current engine.
-                self.ir.retire(old);
+            if self.fading.is_some() {
+                // A second swap landed mid-fade: cutting the fade short would
+                // step the output in one sample, so defer the new engine until
+                // the active fade completes. Newest wins — a displaced pending
+                // engine is retired for off-thread destruction.
+                if let Some(displaced) = self.pending.replace(new_engine) {
+                    self.ir.retire(displaced);
+                }
+            } else {
+                let prev = std::mem::replace(&mut self.current, new_engine);
+                self.fading = Some((prev, 0));
             }
-            let prev = std::mem::replace(&mut self.current, new_engine);
-            self.fading = Some((prev, 0));
         }
 
         let x = self.input;
@@ -566,6 +576,11 @@ impl<F: AudioFrame> SignalProcessor for Convolver<F> {
                 if *pos >= self.fade_len {
                     let (old_arc, _) = self.fading.take().unwrap();
                     self.ir.retire(old_arc); // hand back for off-thread free
+                    if let Some(next) = self.pending.take() {
+                        // Promote the engine deferred mid-fade into a new fade.
+                        let prev = std::mem::replace(&mut self.current, next);
+                        self.fading = Some((prev, 0));
+                    }
                 }
                 mixed
             }

--- a/oscen-lib/src/convolution/tests.rs
+++ b/oscen-lib/src/convolution/tests.rs
@@ -154,6 +154,51 @@ fn convolver_swap_is_click_free() {
     );
 }
 
+/// A second IR published while a crossfade is still in progress must not step
+/// the output: the new engine is deferred until the active fade completes,
+/// then promoted into its own fade (and the newest publish still wins).
+#[test]
+fn convolver_second_swap_mid_fade_is_click_free() {
+    // Single-tap IRs make each engine a pure gain, so with DC input the
+    // output is a crossfade between constants and any fade restart shows up
+    // as a single-sample step.
+    let (mut publisher, consumer) = handoff::pair::<MultiConvolverEngine>();
+    let mut conv = Convolver::with_ir(vec![0.2]);
+    conv.install_ir_consumer(consumer);
+    conv.set_sample_rate(44100.0);
+    conv.prepare();
+
+    let fade = fade_len_at_44k();
+    let dc = vec![1.0f32; 50 + 100 + 3 * fade];
+
+    // Steady state on the 0.2 IR.
+    let mut out = run(&mut conv, &dc[..50]);
+    // Publish B: the fade toward gain 0.6 begins.
+    publisher.publish(MultiConvolverEngine::from_mono_ir(&[0.6], 1));
+    out.extend(run(&mut conv, &dc[50..150]));
+    // Publish C 100 samples into the fade: it must defer, not restart.
+    publisher.publish(MultiConvolverEngine::from_mono_ir(&[1.0], 1));
+    out.extend(run(&mut conv, &dc[150..]));
+
+    // The equal-power fade moves the output by at most (pi/2)/fade of the
+    // gain delta per sample (~0.001 here); the pre-fix fade restart stepped
+    // ~0.3 in one sample.
+    let max_step = (1..out.len())
+        .map(|i| (out[i] - out[i - 1]).abs())
+        .fold(0.0f32, f32::max);
+    assert!(
+        max_step < 0.01,
+        "single-sample step {max_step} exceeds the fade slope"
+    );
+
+    // The deferred engine must eventually land: output settles on C's gain.
+    let last = *out.last().unwrap();
+    assert!(
+        approx_eq!(f32, last, 1.0, epsilon = 1e-4),
+        "pending IR did not land: {last}"
+    );
+}
+
 /// Test 4: a convolver with an installed consumer but nothing published is
 /// exactly silent.
 #[test]

--- a/oscen-lib/src/delay/mod.rs
+++ b/oscen-lib/src/delay/mod.rs
@@ -23,7 +23,7 @@ pub struct Delay {
 impl Delay {
     /// Create a delay with delay time specified in samples/frames.
     pub fn new(delay_samples: f32, feedback: f32) -> Self {
-        // Start with a very small buffer to avoid excessive stack usage
+        // Placeholder size; `prepare` resizes for the actual sample rate.
         let initial_buffer_size = 1024;
 
         Self {
@@ -57,14 +57,12 @@ impl Delay {
 
 impl SignalProcessor for Delay {
     fn prepare(&mut self) {
-        // Calculate a reasonable buffer size based on sample rate, with a safety cap
-        // to prevent potential stack overflows
+        // Size the buffer in time so the maximum delay is the same at every
+        // sample rate. PowerOfTwo mode (the `new` default) is kept for its
+        // mask-based indexing on the audio thread; the rounding up only adds
+        // delay headroom.
         let target_seconds = 2.0;
-        let max_samples = 88200; // Maximum buffer size (2 seconds at 44.1kHz)
-
-        let buffer_size = ((target_seconds * *self.sample_rate) as usize).min(max_samples);
-
-        // Initialize the buffer with a capped size
+        let buffer_size = (target_seconds * *self.sample_rate) as usize;
         self.buffer = RingBuffer::new(buffer_size);
     }
 
@@ -83,3 +81,6 @@ impl SignalProcessor for Delay {
 }
 
 impl AllowsFeedback for Delay {}
+
+#[cfg(test)]
+mod tests;

--- a/oscen-lib/src/delay/mod.rs
+++ b/oscen-lib/src/delay/mod.rs
@@ -1,6 +1,11 @@
+use crate::frame::AudioFrame;
 use crate::graph::{AllowsFeedback, SampleRate, SignalProcessor};
 use crate::ring_buffer::RingBuffer;
 use oscen_macros::Node;
+
+/// Below this magnitude the recirculating feedback tail hits denormals, which
+/// cost ~100× on x86. Same threshold as the halfband IIR's recursive state.
+const DENORMAL_THRESHOLD: f32 = 1e-15;
 
 #[derive(Debug, Node)]
 pub struct Delay {
@@ -71,9 +76,11 @@ impl SignalProcessor for Delay {
         // Update parameters
         self.apply_parameter_updates();
 
-        // Process delay
+        // Process delay. Flush the recirculated value so a decaying feedback
+        // tail snaps to zero instead of ringing through the subnormal range.
         let delayed = self.buffer.get(self.delay_samples);
-        self.buffer.push(self.input + delayed * self.feedback);
+        self.buffer
+            .push((self.input + delayed * self.feedback).flush_denormal(DENORMAL_THRESHOLD));
 
         // Write output
         self.output = delayed;

--- a/oscen-lib/src/delay/tests.rs
+++ b/oscen-lib/src/delay/tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+/// Build a prepared `Delay` (rate distributed before `prepare`, as a graph
+/// would do it).
+fn prepared(delay_samples: f32, feedback: f32, sample_rate: f32) -> Delay {
+    let mut delay = Delay::new(delay_samples, feedback);
+    delay.set_sample_rate(sample_rate);
+    delay.prepare();
+    delay
+}
+
+/// Drive the node one sample at a time, returning the outputs.
+fn run(delay: &mut Delay, input: impl Iterator<Item = f32>) -> Vec<f32> {
+    input
+        .map(|x| {
+            delay.input = x;
+            delay.process();
+            delay.output
+        })
+        .collect()
+}
+
+/// The maximum delay is fixed in *time* (2 s), not in samples: a 1.5 s delay
+/// must survive at 96 kHz instead of being silently clamped to a
+/// 44.1 kHz-sized buffer.
+#[test]
+fn max_delay_is_sample_rate_independent() {
+    let n = 144_000; // 1.5 s at 96 kHz
+    let mut delay = prepared(n as f32, 0.0, 96_000.0);
+
+    let total = n + 100;
+    let out = run(
+        &mut delay,
+        (0..total).map(|t| if t == 0 { 1.0 } else { 0.0 }),
+    );
+
+    let first_nonzero = out.iter().position(|&y| y != 0.0);
+    // The node reads before it writes, so a commanded delay of N samples
+    // emerges N + 1 process calls after the input.
+    assert_eq!(
+        first_nonzero,
+        Some(n + 1),
+        "1.5 s delay at 96 kHz must not be clamped"
+    );
+}

--- a/oscen-lib/src/delay/tests.rs
+++ b/oscen-lib/src/delay/tests.rs
@@ -20,6 +20,32 @@ fn run(delay: &mut Delay, input: impl Iterator<Item = f32>) -> Vec<f32> {
         .collect()
 }
 
+/// A decaying feedback tail must be flushed to zero instead of recirculating
+/// through the f32 subnormal range after the input stops.
+#[test]
+fn feedback_tail_flushes_denormals() {
+    let mut delay = prepared(4.0, 0.9, 44_100.0);
+
+    // One impulse, then silence. The tail decays by 0.9 per 5-sample round
+    // trip and would reach subnormal magnitudes (~1e-38) after roughly 830
+    // trips without the flush.
+    let out = run(
+        &mut delay,
+        (0..6_000).map(|t| if t == 0 { 1.0 } else { 0.0 }),
+    );
+
+    assert!(
+        out.iter().all(|y| !y.is_subnormal()),
+        "output entered the subnormal range"
+    );
+    // The flush snaps the tail to exactly zero once it falls below the
+    // threshold; the final stretch must be dead silence.
+    assert!(
+        out[5_000..].iter().all(|&y| y == 0.0),
+        "tail did not settle to exact zero"
+    );
+}
+
 /// The maximum delay is fixed in *time* (2 s), not in samples: a 1.5 s delay
 /// must survive at 96 kHz instead of being silently clamped to a
 /// 44.1 kHz-sized buffer.

--- a/oscen-lib/src/delay/tests.rs
+++ b/oscen-lib/src/delay/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use float_cmp::assert_approx_eq;
 
 /// Build a prepared `Delay` (rate distributed before `prepare`, as a graph
 /// would do it).
@@ -18,6 +19,107 @@ fn run(delay: &mut Delay, input: impl Iterator<Item = f32>) -> Vec<f32> {
             delay.output
         })
         .collect()
+}
+
+/// An impulse through a commanded integer delay of N comes out as a single
+/// unscaled impulse exactly N + 1 process calls later (the node reads before
+/// it writes, so the commanded delay is measured from the previous sample).
+#[test]
+fn impulse_is_delayed_by_commanded_integer_samples() {
+    let n = 100;
+    let mut delay = prepared(n as f32, 0.0, 44_100.0);
+
+    let out = run(&mut delay, (0..300).map(|t| if t == 0 { 1.0 } else { 0.0 }));
+
+    for (t, &y) in out.iter().enumerate() {
+        let want = if t == n + 1 { 1.0 } else { 0.0 };
+        assert_approx_eq!(f32, y, want, epsilon = 0.0);
+    }
+}
+
+/// A commanded delay of zero is a one-sample delay (read-before-write): the
+/// output is exactly the previous input, passed through untouched.
+#[test]
+fn zero_delay_is_a_one_sample_identity() {
+    let mut delay = prepared(0.0, 0.0, 44_100.0);
+
+    let input: Vec<f32> = (0..200)
+        .map(|t| ((t * 7 % 23) as f32) * 0.05 - 0.5)
+        .collect();
+    let out = run(&mut delay, input.iter().copied());
+
+    assert_approx_eq!(f32, out[0], 0.0, epsilon = 0.0);
+    for t in 1..input.len() {
+        assert_approx_eq!(f32, out[t], input[t - 1], epsilon = 0.0);
+    }
+}
+
+/// With feedback 0.9 an impulse produces a geometrically decaying echo train
+/// that stays bounded; between echoes the output is exactly silent.
+#[test]
+fn feedback_echoes_decay_and_stay_bounded() {
+    let n = 10;
+    let mut delay = prepared(n as f32, 0.9, 44_100.0);
+
+    let out = run(
+        &mut delay,
+        (0..1_000).map(|t| if t == 0 { 1.0 } else { 0.0 }),
+    );
+
+    assert!(out.iter().all(|y| y.abs() <= 1.0), "output must be bounded");
+    // Echo k arrives at t = k * (n + 1) with amplitude 0.9^(k - 1).
+    for k in 1..=5usize {
+        let t = k * (n + 1);
+        let want = 0.9f32.powi(k as i32 - 1);
+        assert_approx_eq!(f32, out[t], want, epsilon = 1e-6);
+        assert_approx_eq!(f32, out[t - 1], 0.0, epsilon = 0.0);
+        assert_approx_eq!(f32, out[t + 1], 0.0, epsilon = 0.0);
+    }
+}
+
+/// Processing more samples than the buffer holds keeps the output correct
+/// across the write-position wrap-around.
+#[test]
+fn output_stays_correct_across_buffer_wrap_around() {
+    // 2 s at 1 kHz -> 2000 requested, 2048 actual capacity; 5000 samples
+    // wraps the buffer more than twice.
+    let n = 100;
+    let mut delay = prepared(n as f32, 0.0, 1_000.0);
+    assert_eq!(delay.buffer.capacity(), 2048);
+
+    let input: Vec<f32> = (0..5_000).map(|t| ((t % 97) as f32) * 0.01).collect();
+    let out = run(&mut delay, input.iter().copied());
+
+    for t in (n + 1)..input.len() {
+        assert_approx_eq!(f32, out[t], input[t - n - 1], epsilon = 0.0);
+    }
+}
+
+/// A fractional delay below one sample must never read the oldest sample in
+/// the buffer: once the impulse has aged to the write position, the output
+/// stays exactly silent (regression for the cubic write-boundary bleed).
+#[test]
+fn fractional_delay_below_one_sample_has_no_stale_bleed() {
+    let mut delay = prepared(0.5, 0.0, 1_000.0);
+    let capacity = delay.buffer.capacity();
+
+    // Impulse, then silence for over a full buffer length. The interpolated
+    // impulse leaves the output within two samples; at t = capacity the
+    // impulse sits at the write position (the oldest sample), where a cubic
+    // read at offset 0.5 used to pick it up at weight -0.0625.
+    let total = capacity + 16;
+    let out = run(
+        &mut delay,
+        (0..total).map(|t| if t == 0 { 1.0 } else { 0.0 }),
+    );
+
+    assert_approx_eq!(f32, out[1], 0.5, epsilon = 1e-6);
+    assert_approx_eq!(f32, out[2], 0.5, epsilon = 1e-6);
+    assert!(
+        out[3..].iter().all(|&y| y == 0.0),
+        "stale sample bled into a sub-sample delay: {:?}",
+        out[3..].iter().find(|&&y| y != 0.0)
+    );
 }
 
 /// A decaying feedback tail must be flushed to zero instead of recirculating

--- a/oscen-lib/src/ring_buffer/mod.rs
+++ b/oscen-lib/src/ring_buffer/mod.rs
@@ -193,7 +193,16 @@ impl RingBuffer {
         // Choose interpolation method based on available capacity.
         // Pass the original non-negative (but potentially > capacity) offset
         // to the interpolation functions. `read_pos` inside them handles wrapping.
-        if self.capacity >= 4 {
+        //
+        // Near the ends of the buffer the cubic's outer taps cross the write
+        // boundary: for offsets in (0, 1) the fourth tap lands on write_pos
+        // (the oldest sample), and for offsets in (capacity - 2, capacity - 1)
+        // the first tap lands on the newest sample. Fall back to linear there —
+        // its two taps stay on the correct side of the write boundary.
+        if self.capacity >= 4
+            && non_negative_offset >= 1.0
+            && non_negative_offset <= self.capacity as f32 - 2.0
+        {
             self.get_cubic(non_negative_offset)
         } else {
             self.get_linear(non_negative_offset)

--- a/oscen-lib/src/ring_buffer/tests.rs
+++ b/oscen-lib/src/ring_buffer/tests.rs
@@ -214,6 +214,39 @@ fn test_get_cubic_interpolation() {
 }
 
 #[test]
+fn test_fractional_offset_below_one_ignores_oldest_sample() {
+    // The oldest sample sits at write_pos. A cubic read at a sub-sample
+    // offset would place its fourth tap there, bleeding seconds-old audio
+    // into a near-zero delay. `get` must not touch it.
+    let mut buf = RingBuffer::with_mode(8, BufferMode::PowerOfTwo);
+    buf.push(1.0); // idx 0
+    for _ in 0..7 {
+        buf.push(0.0); // idx 1..=7, write_pos wraps to 0
+    }
+    // Buffer: [1.0, 0, 0, 0, 0, 0, 0, 0], write_pos = 0. The 1.0 at
+    // write_pos is the OLDEST sample; everything recent is silence.
+    assert_approx_eq!(f32, buf.get(0.5), 0.0, epsilon = 1e-6);
+    assert_approx_eq!(f32, buf.get(0.25), 0.0, epsilon = 1e-6);
+    assert_approx_eq!(f32, buf.get(0.75), 0.0, epsilon = 1e-6);
+}
+
+#[test]
+fn test_fractional_offset_near_capacity_ignores_newest_sample() {
+    // Symmetric case: a cubic read near the longest delay would place its
+    // first tap on the newest sample. `get` must not touch it.
+    let mut buf = RingBuffer::with_mode(8, BufferMode::PowerOfTwo);
+    for _ in 0..7 {
+        buf.push(0.0); // idx 0..=6
+    }
+    buf.push(1.0); // idx 7, write_pos wraps to 0
+                   // Buffer: [0, 0, 0, 0, 0, 0, 0, 1.0], write_pos = 0. The 1.0 is the
+                   // NEWEST sample; everything older is silence.
+    assert_approx_eq!(f32, buf.get(6.5), 0.0, epsilon = 1e-6);
+    assert_approx_eq!(f32, buf.get(6.25), 0.0, epsilon = 1e-6);
+    assert_approx_eq!(f32, buf.get(6.75), 0.0, epsilon = 1e-6);
+}
+
+#[test]
 fn test_minimum_capacity() {
     // Renamed from test_empty_buffer
     // Test with minimum N and size 0 -> capacity 1


### PR DESCRIPTION
Fixes four confirmed review findings plus a missing test module:

- RingBuffer: at fractional offsets below 1 (or above capacity - 2) the cubic interpolator's outer taps crossed the write boundary, mixing the oldest sample in the buffer (up to seconds-old audio at ~-22 dB) into short delays — reachable by any flanger-style sweep toward zero. get() now falls back to linear interpolation near the boundaries, where its two taps stay on the correct side.
- Delay: the buffer was sized min(2s x rate, 88200 samples), so max delay time shrank with sample rate (~0.68 s at 192 kHz) and the same patch behaved differently per rate; the cap's stack-overflow rationale was stale (the buffer is heap-allocated). Now sized purely in time. PowerOfTwo mode kept after assessing Exact mode: correct but costs a hardware division per tap on the RT path vs mask ANDs.
- Convolver: a second IR published mid-crossfade retired the outgoing engine instantly and restarted the fade, stepping the output in one sample (measured 0.298 discontinuity). New engines arriving mid-fade are now deferred (newest wins) and promoted when the active fade completes; displaced engines retire through the existing off-thread disposal path.
- Delay: the feedback push now flushes denormals with the halfband IIR's threshold.

Adds the previously missing Delay test module (7 tests: impulse timing, zero-delay behavior, feedback boundedness, wrap-around, fractional-delay bleed regression, rate-independent sizing, denormal flush).

Note: the tests pin the Delay's actual latency of N+1 samples (it reads before writing); making it exactly N is a separate, feedback-entangled change.