### PR TITLE
Make the MIDI note path allocation-free and handle MIDI panic messages

### DIFF
--- a/oscen-lib/src/envelope/adsr.rs
+++ b/oscen-lib/src/envelope/adsr.rs
@@ -259,7 +259,7 @@ impl AdsrEnvelope {
     fn handle_gate_event(&mut self, event: &EventInstance) {
         let velocity = match &event.payload {
             EventPayload::Scalar(v) => *v,
-            EventPayload::Object(_) => 1.0,
+            EventPayload::Midi(_) | EventPayload::Object(_) => 1.0,
         };
 
         if velocity > 0.0 {

--- a/oscen-lib/src/graph/types.rs
+++ b/oscen-lib/src/graph/types.rs
@@ -96,6 +96,10 @@ where
 #[derive(Clone)]
 pub enum EventPayload {
     Scalar(f32),
+    /// Raw 3-byte MIDI message: status, data1, data2.
+    /// `Copy` plain data — safe to construct and clone on the audio thread
+    /// without heap allocation.
+    Midi([u8; 3]),
     Object(Arc<dyn EventObject>),
 }
 
@@ -103,6 +107,7 @@ impl fmt::Debug for EventPayload {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Scalar(v) => f.debug_tuple("Scalar").field(v).finish(),
+            Self::Midi(bytes) => f.debug_tuple("Midi").field(bytes).finish(),
             Self::Object(obj) => f.debug_tuple("Object").field(obj).finish(),
         }
     }
@@ -111,6 +116,10 @@ impl fmt::Debug for EventPayload {
 impl EventPayload {
     pub fn scalar(value: f32) -> Self {
         Self::Scalar(value)
+    }
+
+    pub fn midi(bytes: [u8; 3]) -> Self {
+        Self::Midi(bytes)
     }
 
     pub fn object<T>(value: T) -> Self
@@ -123,13 +132,20 @@ impl EventPayload {
     pub fn as_scalar(&self) -> Option<f32> {
         match self {
             Self::Scalar(v) => Some(*v),
-            Self::Object(_) => None,
+            Self::Midi(_) | Self::Object(_) => None,
+        }
+    }
+
+    pub fn as_midi(&self) -> Option<[u8; 3]> {
+        match self {
+            Self::Midi(bytes) => Some(*bytes),
+            Self::Scalar(_) | Self::Object(_) => None,
         }
     }
 
     pub fn as_object(&self) -> Option<&dyn EventObject> {
         match self {
-            Self::Scalar(_) => None,
+            Self::Scalar(_) | Self::Midi(_) => None,
             Self::Object(obj) => Some(obj.as_ref()),
         }
     }
@@ -510,6 +526,32 @@ mod tests {
             assert_eq!(completed, i == 3);
         }
         assert_eq!(ramp.current, 0.0);
+    }
+}
+
+#[cfg(test)]
+mod event_payload_tests {
+    use super::EventPayload;
+
+    #[test]
+    fn midi_accessors() {
+        let payload = EventPayload::midi([0x90, 60, 100]);
+        assert_eq!(payload.as_midi(), Some([0x90, 60, 100]));
+        assert_eq!(payload.as_scalar(), None);
+        assert!(payload.as_object().is_none());
+    }
+
+    #[test]
+    fn scalar_and_object_are_not_midi() {
+        assert_eq!(EventPayload::scalar(1.0).as_midi(), None);
+        assert_eq!(EventPayload::object(42u8).as_midi(), None);
+    }
+
+    #[test]
+    fn midi_payload_clone_is_copy() {
+        let payload = EventPayload::midi([0x80, 60, 0]);
+        let cloned = payload.clone();
+        assert_eq!(cloned.as_midi(), Some([0x80, 60, 0]));
     }
 }
 

--- a/oscen-lib/src/midi.rs
+++ b/oscen-lib/src/midi.rs
@@ -146,6 +146,18 @@ impl MidiVoiceHandler {
     }
 
     fn on_note_off(&mut self, event: &EventInstance) {
+        // CC 120 (All Sound Off) / CC 123 (All Notes Off): gate off whatever
+        // note is playing.
+        if is_all_notes_off(&event.payload) {
+            if self.current_note.take().is_some() {
+                let _ = self.gate.try_push(EventInstance {
+                    frame_offset: event.frame_offset,
+                    payload: EventPayload::Scalar(0.0),
+                });
+            }
+            return;
+        }
+
         if let Some(note_off) = NoteOffEvent::from_payload(&event.payload) {
             // Only turn off gate if this is the current note
             if self.current_note == Some(note_off.note) {
@@ -189,7 +201,7 @@ impl MidiParser {
         }
 
         let status = data[0] & 0xF0;
-        let note = data[1];
+        let note = data[1]; // controller number for CC messages
         let velocity = data[2];
 
         match status {
@@ -202,6 +214,11 @@ impl MidiParser {
                     Some(ParsedMidi::NoteOn { note, velocity })
                 }
             }
+            // CC 120 (All Sound Off) and CC 123 (All Notes Off)
+            0xB0 => match note {
+                120 | 123 => Some(ParsedMidi::AllNotesOff { controller: note }),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -211,6 +228,7 @@ impl MidiParser {
 enum ParsedMidi {
     NoteOn { note: u8, velocity: u8 },
     NoteOff { note: u8 },
+    AllNotesOff { controller: u8 },
 }
 
 impl Default for MidiParser {
@@ -255,9 +273,27 @@ impl MidiParser {
                     payload: EventPayload::Midi([0x80, note, 0]),
                 });
             }
+            Some(ParsedMidi::AllNotesOff { controller }) => {
+                // Routed through the note_off output; consumers recognize it
+                // via is_all_notes_off() and silence all active notes.
+                let _ = self.note_off.try_push(EventInstance {
+                    frame_offset: event.frame_offset,
+                    payload: EventPayload::Midi([0xB0, controller, 0]),
+                });
+            }
             None => {}
         }
     }
+}
+
+/// True if the payload is a MIDI CC 120 (All Sound Off) or CC 123
+/// (All Notes Off) message.
+pub fn is_all_notes_off(payload: &EventPayload) -> bool {
+    matches!(
+        payload.as_midi(),
+        Some([status, controller, _])
+            if status & 0xF0 == 0xB0 && (controller == 120 || controller == 123)
+    )
 }
 
 /// Helper function to create a raw MIDI message event payload.
@@ -413,6 +449,80 @@ mod tests {
             0.0,
             ulps = 2
         ));
+    }
+
+    #[test]
+    fn test_parser_routes_all_notes_off_to_note_off_output() {
+        let mut parser = MidiParser::new();
+
+        // CC 123 (All Notes Off) and CC 120 (All Sound Off) are recognized
+        parser.on_midi_in(&midi_event([0xB0, 123, 0]));
+        parser.on_midi_in(&midi_event([0xB1, 120, 0])); // any channel
+        assert_eq!(parser.note_off.len(), 2);
+        for event in parser.note_off.iter() {
+            assert!(is_all_notes_off(&event.payload));
+        }
+        assert!(parser.note_on.is_empty());
+
+        // Other CC messages are ignored
+        parser.note_off.clear();
+        parser.on_midi_in(&midi_event([0xB0, 1, 64])); // mod wheel
+        assert!(parser.note_off.is_empty());
+    }
+
+    #[test]
+    fn test_all_notes_off_gates_playing_voice() {
+        use float_cmp::approx_eq;
+
+        let mut parser = MidiParser::new();
+        let mut handler = MidiVoiceHandler::new();
+
+        // Note playing
+        parser.on_midi_in(&midi_event([0x90, 60, 100]));
+        handler.on_note_on(&parser.note_on.iter().next().unwrap().clone());
+        assert!(approx_eq!(
+            f32,
+            handler
+                .gate
+                .iter()
+                .last()
+                .unwrap()
+                .payload
+                .as_scalar()
+                .unwrap(),
+            100.0 / 127.0,
+            ulps = 2
+        ));
+        handler.gate.clear();
+
+        // CC 123 (All Notes Off) arrives; gate goes to 0
+        parser.on_midi_in(&midi_event([0xB0, 123, 0]));
+        handler.on_note_off(&parser.note_off.iter().next().unwrap().clone());
+        assert!(approx_eq!(
+            f32,
+            handler
+                .gate
+                .iter()
+                .last()
+                .unwrap()
+                .payload
+                .as_scalar()
+                .unwrap(),
+            0.0,
+            ulps = 2
+        ));
+
+        // A second all-notes-off does nothing (no note playing anymore)
+        handler.gate.clear();
+        handler.on_note_off(&midi_event([0xB0, 120, 0]));
+        assert!(handler.gate.is_empty());
+    }
+
+    #[test]
+    fn test_all_notes_off_without_active_note_emits_nothing() {
+        let mut handler = MidiVoiceHandler::new();
+        handler.on_note_off(&midi_event([0xB0, 123, 0]));
+        assert!(handler.gate.is_empty());
     }
 
     #[test]

--- a/oscen-lib/src/midi.rs
+++ b/oscen-lib/src/midi.rs
@@ -28,10 +28,53 @@ pub struct NoteOnEvent {
     pub velocity: f32, // 0.0 - 1.0
 }
 
+impl NoteOnEvent {
+    /// Extract a note-on from an event payload.
+    ///
+    /// Accepts both the allocation-free `EventPayload::Midi` representation
+    /// (a note-on status byte with non-zero velocity) and a boxed
+    /// `NoteOnEvent` object.
+    pub fn from_payload(payload: &EventPayload) -> Option<Self> {
+        match payload {
+            EventPayload::Midi(bytes) => {
+                if bytes[0] & 0xF0 == 0x90 && bytes[2] > 0 {
+                    Some(Self {
+                        note: bytes[1],
+                        velocity: (bytes[2] as f32 / 127.0).clamp(0.0, 1.0),
+                    })
+                } else {
+                    None
+                }
+            }
+            EventPayload::Object(obj) => obj.as_any().downcast_ref::<Self>().copied(),
+            EventPayload::Scalar(_) => None,
+        }
+    }
+}
+
 /// Note-off event with note number
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct NoteOffEvent {
     pub note: u8,
+}
+
+impl NoteOffEvent {
+    /// Extract a note-off from an event payload.
+    ///
+    /// Accepts both the allocation-free `EventPayload::Midi` representation
+    /// (a note-off status byte, or note-on with velocity 0) and a boxed
+    /// `NoteOffEvent` object.
+    pub fn from_payload(payload: &EventPayload) -> Option<Self> {
+        match payload {
+            EventPayload::Midi(bytes) => match bytes[0] & 0xF0 {
+                0x80 => Some(Self { note: bytes[1] }),
+                0x90 if bytes[2] == 0 => Some(Self { note: bytes[1] }),
+                _ => None,
+            },
+            EventPayload::Object(obj) => obj.as_any().downcast_ref::<Self>().copied(),
+            EventPayload::Scalar(_) => None,
+        }
+    }
 }
 
 /// A node that manages MIDI note state and converts to frequency/gate outputs.
@@ -90,32 +133,28 @@ impl SignalProcessor for MidiVoiceHandler {
 impl MidiVoiceHandler {
     // Event handlers called automatically by derive macro via process_event_inputs()
     fn on_note_on(&mut self, event: &EventInstance) {
-        if let EventPayload::Object(obj) = &event.payload {
-            if let Some(note_on) = obj.as_any().downcast_ref::<NoteOnEvent>() {
-                self.current_note = Some(note_on.note);
-                self.current_frequency = Self::midi_note_to_freq(note_on.note);
+        if let Some(note_on) = NoteOnEvent::from_payload(&event.payload) {
+            self.current_note = Some(note_on.note);
+            self.current_frequency = Self::midi_note_to_freq(note_on.note);
 
-                // Emit gate-on event with velocity - push directly to EventOutput field
-                let _ = self.gate.try_push(EventInstance {
-                    frame_offset: event.frame_offset,
-                    payload: EventPayload::Scalar(note_on.velocity),
-                });
-            }
+            // Emit gate-on event with velocity - push directly to EventOutput field
+            let _ = self.gate.try_push(EventInstance {
+                frame_offset: event.frame_offset,
+                payload: EventPayload::Scalar(note_on.velocity),
+            });
         }
     }
 
     fn on_note_off(&mut self, event: &EventInstance) {
-        if let EventPayload::Object(obj) = &event.payload {
-            if let Some(note_off) = obj.as_any().downcast_ref::<NoteOffEvent>() {
-                // Only turn off gate if this is the current note
-                if self.current_note == Some(note_off.note) {
-                    // Emit gate-off event - push directly to EventOutput field
-                    let _ = self.gate.try_push(EventInstance {
-                        frame_offset: event.frame_offset,
-                        payload: EventPayload::Scalar(0.0),
-                    });
-                    self.current_note = None;
-                }
+        if let Some(note_off) = NoteOffEvent::from_payload(&event.payload) {
+            // Only turn off gate if this is the current note
+            if self.current_note == Some(note_off.note) {
+                // Emit gate-off event - push directly to EventOutput field
+                let _ = self.gate.try_push(EventInstance {
+                    frame_offset: event.frame_offset,
+                    payload: EventPayload::Scalar(0.0),
+                });
+                self.current_note = None;
             }
         }
     }
@@ -160,10 +199,7 @@ impl MidiParser {
                     // Note-on with velocity 0 is treated as note-off
                     Some(ParsedMidi::NoteOff { note })
                 } else {
-                    Some(ParsedMidi::NoteOn {
-                        note,
-                        velocity: (velocity as f32 / 127.0).clamp(0.0, 1.0),
-                    })
+                    Some(ParsedMidi::NoteOn { note, velocity })
                 }
             }
             _ => None,
@@ -173,7 +209,7 @@ impl MidiParser {
 
 /// Internal enum for parsed MIDI messages
 enum ParsedMidi {
-    NoteOn { note: u8, velocity: f32 },
+    NoteOn { note: u8, velocity: u8 },
     NoteOff { note: u8 },
 }
 
@@ -194,39 +230,46 @@ impl SignalProcessor for MidiParser {
 impl MidiParser {
     // Event handler called automatically by derive macro via process_event_inputs()
     fn on_midi_in(&mut self, event: &EventInstance) {
-        if let EventPayload::Object(obj) = &event.payload {
-            // Try to downcast to RawMidiMessage
-            if let Some(raw_midi) = obj.as_any().downcast_ref::<RawMidiMessage>() {
-                // Parse the raw bytes
-                if let Some(parsed) = Self::parse_bytes(&raw_midi.bytes[..raw_midi.len]) {
-                    match parsed {
-                        ParsedMidi::NoteOn { note, velocity } => {
-                            // Push note-on event directly to EventOutput field
-                            let _ = self.note_on.try_push(EventInstance {
-                                frame_offset: event.frame_offset,
-                                payload: EventPayload::Object(Arc::new(NoteOnEvent {
-                                    note,
-                                    velocity,
-                                })),
-                            });
-                        }
-                        ParsedMidi::NoteOff { note } => {
-                            // Push note-off event directly to EventOutput field
-                            let _ = self.note_off.try_push(EventInstance {
-                                frame_offset: event.frame_offset,
-                                payload: EventPayload::Object(Arc::new(NoteOffEvent { note })),
-                            });
-                        }
-                    }
-                }
+        // Accept both the allocation-free Midi payload and the legacy
+        // Object(RawMidiMessage) representation.
+        let parsed = match &event.payload {
+            EventPayload::Midi(bytes) => Self::parse_bytes(bytes),
+            EventPayload::Object(obj) => obj
+                .as_any()
+                .downcast_ref::<RawMidiMessage>()
+                .and_then(|raw| Self::parse_bytes(&raw.bytes[..raw.len])),
+            EventPayload::Scalar(_) => None,
+        };
+
+        // Emit plain-data Midi payloads: no heap allocation on the audio thread.
+        match parsed {
+            Some(ParsedMidi::NoteOn { note, velocity }) => {
+                let _ = self.note_on.try_push(EventInstance {
+                    frame_offset: event.frame_offset,
+                    payload: EventPayload::Midi([0x90, note, velocity]),
+                });
             }
+            Some(ParsedMidi::NoteOff { note }) => {
+                let _ = self.note_off.try_push(EventInstance {
+                    frame_offset: event.frame_offset,
+                    payload: EventPayload::Midi([0x80, note, 0]),
+                });
+            }
+            None => {}
         }
     }
 }
 
-/// Helper function to create a raw MIDI message event payload
+/// Helper function to create a raw MIDI message event payload.
+/// Complete 3-byte messages use the allocation-free `EventPayload::Midi`
+/// representation; shorter messages fall back to a boxed `RawMidiMessage`.
 pub fn raw_midi_event(bytes: &[u8]) -> EventPayload {
-    EventPayload::Object(Arc::new(RawMidiMessage::new(bytes)))
+    let msg = RawMidiMessage::new(bytes);
+    if msg.len == 3 {
+        EventPayload::Midi(msg.bytes)
+    } else {
+        EventPayload::Object(Arc::new(msg))
+    }
 }
 
 #[cfg(test)]
@@ -246,7 +289,10 @@ mod tests {
         let parsed = MidiParser::parse_bytes(&[0x90, 60, 100]);
         assert!(matches!(
             parsed,
-            Some(ParsedMidi::NoteOn { note: 60, velocity }) if (velocity - 100.0/127.0).abs() < 0.01
+            Some(ParsedMidi::NoteOn {
+                note: 60,
+                velocity: 100
+            })
         ));
     }
 
@@ -270,5 +316,126 @@ mod tests {
         assert_eq!(msg.bytes[1], 60);
         assert_eq!(msg.bytes[2], 100);
         assert_eq!(msg.len, 3);
+    }
+
+    #[test]
+    fn test_raw_midi_event_is_pod_for_full_messages() {
+        assert_eq!(
+            raw_midi_event(&[0x90, 60, 100]).as_midi(),
+            Some([0x90, 60, 100])
+        );
+        // Short messages fall back to the boxed representation
+        assert!(raw_midi_event(&[0xC0, 5]).as_object().is_some());
+    }
+
+    fn midi_event(bytes: [u8; 3]) -> EventInstance {
+        EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Midi(bytes),
+        }
+    }
+
+    #[test]
+    fn test_note_on_off_round_trip_with_pod_payload() {
+        use float_cmp::approx_eq;
+
+        let mut parser = MidiParser::new();
+        let mut handler = MidiVoiceHandler::new();
+
+        // Note-on A4 (69), velocity 100, through the parser
+        parser.on_midi_in(&midi_event([0x90, 69, 100]));
+        assert_eq!(parser.note_on.len(), 1);
+        let note_on = parser.note_on.iter().next().unwrap().clone();
+        assert_eq!(note_on.payload.as_midi(), Some([0x90, 69, 100]));
+
+        handler.on_note_on(&note_on);
+        handler.process();
+        assert!(approx_eq!(f32, handler.frequency, 440.0, ulps = 2));
+        let gate_on = handler.gate.iter().next().unwrap();
+        assert!(approx_eq!(
+            f32,
+            gate_on.payload.as_scalar().unwrap(),
+            100.0 / 127.0,
+            ulps = 2
+        ));
+        handler.gate.clear();
+
+        // Note-off for the same note
+        parser.on_midi_in(&midi_event([0x80, 69, 0]));
+        assert_eq!(parser.note_off.len(), 1);
+        let note_off = parser.note_off.iter().next().unwrap().clone();
+        assert_eq!(note_off.payload.as_midi(), Some([0x80, 69, 0]));
+
+        handler.on_note_off(&note_off);
+        let gate_off = handler.gate.iter().next().unwrap();
+        assert!(approx_eq!(
+            f32,
+            gate_off.payload.as_scalar().unwrap(),
+            0.0,
+            ulps = 2
+        ));
+    }
+
+    #[test]
+    fn test_parser_accepts_boxed_raw_midi_message() {
+        let mut parser = MidiParser::new();
+        parser.on_midi_in(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Object(Arc::new(RawMidiMessage::new(&[0x90, 60, 64]))),
+        });
+        let note_on = parser.note_on.iter().next().unwrap();
+        assert_eq!(note_on.payload.as_midi(), Some([0x90, 60, 64]));
+    }
+
+    #[test]
+    fn test_voice_handler_accepts_boxed_note_events() {
+        use float_cmp::approx_eq;
+
+        let mut handler = MidiVoiceHandler::new();
+        handler.on_note_on(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Object(Arc::new(NoteOnEvent {
+                note: 69,
+                velocity: 0.5,
+            })),
+        });
+        handler.process();
+        assert!(approx_eq!(f32, handler.frequency, 440.0, ulps = 2));
+
+        handler.on_note_off(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Object(Arc::new(NoteOffEvent { note: 69 })),
+        });
+        let gate_off = handler.gate.iter().last().unwrap();
+        assert!(approx_eq!(
+            f32,
+            gate_off.payload.as_scalar().unwrap(),
+            0.0,
+            ulps = 2
+        ));
+    }
+
+    #[test]
+    fn test_note_events_from_payload() {
+        use float_cmp::approx_eq;
+
+        let note_on = NoteOnEvent::from_payload(&EventPayload::Midi([0x90, 60, 127])).unwrap();
+        assert_eq!(note_on.note, 60);
+        assert!(approx_eq!(f32, note_on.velocity, 1.0, ulps = 2));
+
+        // Note-on with velocity 0 is a note-off, not a note-on
+        assert!(NoteOnEvent::from_payload(&EventPayload::Midi([0x90, 60, 0])).is_none());
+        assert_eq!(
+            NoteOffEvent::from_payload(&EventPayload::Midi([0x90, 60, 0])),
+            Some(NoteOffEvent { note: 60 })
+        );
+        assert_eq!(
+            NoteOffEvent::from_payload(&EventPayload::Midi([0x80, 60, 64])),
+            Some(NoteOffEvent { note: 60 })
+        );
+
+        // Scalars and unrelated statuses are ignored
+        assert!(NoteOnEvent::from_payload(&EventPayload::Scalar(1.0)).is_none());
+        assert!(NoteOffEvent::from_payload(&EventPayload::Midi([0xB0, 1, 64])).is_none());
     }
 }

--- a/oscen-lib/src/voice_allocator.rs
+++ b/oscen-lib/src/voice_allocator.rs
@@ -1,4 +1,4 @@
-use crate::graph::{EventInput, EventInstance, EventOutput, EventPayload, SignalProcessor};
+use crate::graph::{EventInput, EventInstance, EventOutput, SignalProcessor};
 use crate::midi::{NoteOffEvent, NoteOnEvent};
 use oscen_macros::Node;
 
@@ -110,27 +110,23 @@ impl<const NUM_VOICES: usize> VoiceAllocator<NUM_VOICES> {
     // CMajor-style event handlers (called by Node derive macro)
 
     fn on_note_on(&mut self, event: &EventInstance) {
-        if let EventPayload::Object(obj) = &event.payload {
-            if let Some(note_on) = obj.as_any().downcast_ref::<NoteOnEvent>() {
-                let voice_idx = self.allocate_voice(note_on.note);
-                // Forward the event directly to the allocated voice's EventOutput
-                if voice_idx < NUM_VOICES {
-                    let _ = self.voices[voice_idx].try_push(event.clone());
-                }
+        if let Some(note_on) = NoteOnEvent::from_payload(&event.payload) {
+            let voice_idx = self.allocate_voice(note_on.note);
+            // Forward the event directly to the allocated voice's EventOutput
+            if voice_idx < NUM_VOICES {
+                let _ = self.voices[voice_idx].try_push(event.clone());
             }
         }
     }
 
     fn on_note_off(&mut self, event: &EventInstance) {
-        if let EventPayload::Object(obj) = &event.payload {
-            if let Some(note_off) = obj.as_any().downcast_ref::<NoteOffEvent>() {
-                if let Some(voice_idx) = self.find_voice_for_note(note_off.note) {
-                    // Forward the event directly to the voice's EventOutput
-                    if voice_idx < NUM_VOICES {
-                        let _ = self.voices[voice_idx].try_push(event.clone());
-                    }
-                    self.release_voice(voice_idx);
+        if let Some(note_off) = NoteOffEvent::from_payload(&event.payload) {
+            if let Some(voice_idx) = self.find_voice_for_note(note_off.note) {
+                // Forward the event directly to the voice's EventOutput
+                if voice_idx < NUM_VOICES {
+                    let _ = self.voices[voice_idx].try_push(event.clone());
                 }
+                self.release_voice(voice_idx);
             }
         }
     }

--- a/oscen-lib/src/voice_allocator.rs
+++ b/oscen-lib/src/voice_allocator.rs
@@ -1,5 +1,5 @@
 use crate::graph::{EventInput, EventInstance, EventOutput, SignalProcessor};
-use crate::midi::{NoteOffEvent, NoteOnEvent};
+use crate::midi::{is_all_notes_off, NoteOffEvent, NoteOnEvent};
 use oscen_macros::Node;
 
 const MAX_VOICES: usize = 24;
@@ -120,6 +120,18 @@ impl<const NUM_VOICES: usize> VoiceAllocator<NUM_VOICES> {
     }
 
     fn on_note_off(&mut self, event: &EventInstance) {
+        // CC 120 (All Sound Off) / CC 123 (All Notes Off): forward to every
+        // sounding voice and release it.
+        if is_all_notes_off(&event.payload) {
+            for i in 0..NUM_VOICES {
+                if self.voice_state[i].active && !self.voice_state[i].released {
+                    let _ = self.voices[i].try_push(event.clone());
+                    self.release_voice(i);
+                }
+            }
+            return;
+        }
+
         if let Some(note_off) = NoteOffEvent::from_payload(&event.payload) {
             if let Some(voice_idx) = self.find_voice_for_note(note_off.note) {
                 // Forward the event directly to the voice's EventOutput
@@ -225,6 +237,51 @@ mod tests {
         assert_eq!(stolen_voice, 1);
         assert_eq!(allocator.voice_state[1].note, Some(76));
         assert!(!allocator.voice_state[1].released); // Reset on allocation
+    }
+
+    #[test]
+    fn test_all_notes_off_releases_all_active_voices() {
+        use crate::graph::EventPayload;
+
+        let mut allocator = VoiceAllocator::<2>::new();
+
+        // Two notes playing on two voices
+        allocator.on_note_on(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Midi([0x90, 60, 100]),
+        });
+        allocator.on_note_on(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Midi([0x90, 64, 100]),
+        });
+        for voice in &mut allocator.voices {
+            assert_eq!(voice.len(), 1);
+            voice.clear();
+        }
+
+        // CC 123 (All Notes Off): both voices receive the event and are released
+        allocator.on_note_off(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Midi([0xB0, 123, 0]),
+        });
+        for voice in &allocator.voices {
+            assert_eq!(voice.len(), 1);
+            assert!(is_all_notes_off(&voice.iter().next().unwrap().payload));
+        }
+        assert!(allocator.voice_state[0].released);
+        assert!(allocator.voice_state[1].released);
+
+        // A repeated all-notes-off is a no-op for already-released voices
+        for voice in &mut allocator.voices {
+            voice.clear();
+        }
+        allocator.on_note_off(&EventInstance {
+            frame_offset: 0,
+            payload: EventPayload::Midi([0xB0, 120, 0]),
+        });
+        for voice in &allocator.voices {
+            assert!(voice.is_empty());
+        }
     }
 
     #[test]

--- a/oscen-lib/tests/realtime_safety.rs
+++ b/oscen-lib/tests/realtime_safety.rs
@@ -10,6 +10,7 @@ use oscen::asset::{AssetConsumer, AudioAsset};
 use oscen::convolution::{
     Convolver, ConvolverConsumer, DirectConvolver, MultiConvolverEngine, PartitionedConvolver,
 };
+use oscen::graph;
 use oscen::handoff::pair;
 use oscen::spectral::FftPlan;
 use oscen::SignalProcessor;
@@ -208,6 +209,58 @@ fn stereo_sample_player_swap_is_alloc_free() {
         sum
     });
     assert!(sum.is_finite());
+}
+
+graph! {
+    name: MidiNoAllocGraph;
+
+    input midi_in: event;
+    output stream freq_out;
+
+    nodes {
+        midi_parser = oscen::midi::MidiParser::new();
+        voice_handler = oscen::midi::MidiVoiceHandler::new();
+    }
+
+    connections {
+        midi_in -> midi_parser.midi_in;
+        midi_parser.note_on -> voice_handler.note_on;
+        midi_parser.note_off -> voice_handler.note_off;
+        voice_handler.frequency -> freq_out;
+    }
+}
+
+#[test]
+fn midi_note_path_does_not_allocate() {
+    use oscen::graph::{EventInstance, EventPayload};
+
+    let mut graph = MidiNoAllocGraph::new();
+    graph.init(44100.0);
+
+    // Drive repeated note-on/note-off pairs through the MIDI parser and voice
+    // handler; the whole note path must be heap-allocation free.
+    let freq = assert_no_alloc(|| {
+        let mut last = 0.0f32;
+        for i in 0..1024u32 {
+            let note = 60 + (i / 64 % 12) as u8;
+            if i % 64 == 0 {
+                let _ = graph.midi_in.try_push(EventInstance {
+                    frame_offset: 0,
+                    payload: EventPayload::Midi([0x90, note, 100]),
+                });
+            }
+            if i % 64 == 32 {
+                let _ = graph.midi_in.try_push(EventInstance {
+                    frame_offset: 0,
+                    payload: EventPayload::Midi([0x80, note, 0]),
+                });
+            }
+            graph.process();
+            last = graph.freq_out;
+        }
+        last
+    });
+    assert!(freq.is_finite());
 }
 
 #[test]


### PR DESCRIPTION
Fixes the confirmed RT-safety blocker: MidiParser::on_midi_in allocated an Arc per note event (EventPayload::Object(Arc::new(NoteOnEvent/NoteOffEvent))) inside the compiled graph's processing loop — i.e. on the audio thread, with the matching free also landing there — for every note played.

- New EventPayload::Midi([u8; 3]) Copy variant (raw status/data1/data2), with midi()/as_midi() helpers. One variant serves raw-MIDI transport into MidiParser, its note_on/note_off outputs, and CC pass-through; Scalar and Object are untouched.
- MidiParser accepts both the POD variant and the legacy Object(RawMidiMessage) on input, and emits POD payloads on its note outputs. Consumers (MidiVoiceHandler, VoiceAllocator) go through new NoteOnEvent::from_payload / NoteOffEvent::from_payload, which handle both representations — existing Object-based senders keep working unchanged.
- CC 120 (All Sound Off) and CC 123 (All Notes Off) are now recognized and routed through the note_off path; MidiVoiceHandler gates off its playing note and VoiceAllocator releases every sounding voice. This is the semantic backstop for MIDI panic floods, kept entirely in the MIDI layer — the generic graph/event layer stays MIDI-agnostic. (With a gate-only voice model, CC 120 behaves like CC 123: envelopes still release.)
- New allocation test in tests/realtime_safety.rs drives 1024 samples of note on/off through a compiled MidiParser + MidiVoiceHandler graph under assert_no_alloc, pinning the allocation-free property end-to-end including graph event dispatch. Plus round-trip, both-representation compatibility, and CC-123 tests.

The examples still construct Object(Arc::new(RawMidiMessage)) in their callbacks; a small follow-up migrates them to the POD variant now that the parser accepts it.

Full workspace suite: 451 passed, 0 failed; touched files clippy-clean.