### PR TITLE
Defer events beyond the current block instead of dropping them

### DIFF
--- a/oscen-graph-compiler/src/codegen/mod.rs
+++ b/oscen-graph-compiler/src/codegen/mod.rs
@@ -861,6 +861,25 @@ impl<'a> CodegenContext<'a> {
             })
             .collect();
 
+        let leftover_requeues: Vec<_> = event_inputs
+            .iter()
+            .map(|node| {
+                let name = &node.name;
+                let staged_name = syn::Ident::new(&format!("__staged_{}", name), name.span());
+                let cursor_name = syn::Ident::new(&format!("__cursor_{}", name), name.span());
+                quote! {
+                    while #cursor_name < #staged_name.len() {
+                        let mut __e = #staged_name[#cursor_name].clone();
+                        __e.frame_offset -= frames as u32;
+                        ::oscen::graph::debug_assert_event_pushed(
+                            self.#name.try_push(__e),
+                        );
+                        #cursor_name += 1;
+                    }
+                }
+            })
+            .collect();
+
         let event_input_clearing = self.generate_event_input_clearing();
 
         Ok(quote! {
@@ -868,6 +887,8 @@ impl<'a> CodegenContext<'a> {
             /// Stream inputs should be written to `*_block` arrays before calling.
             /// Stream outputs will be available in `*_block` arrays after calling.
             /// Events should be pushed to event input queues with appropriate `frame_offset` values.
+            /// Events whose `frame_offset` lands beyond `frames` are deferred: they stay queued
+            /// with the offset rebased so they fire sample-accurately in a later block.
             pub fn process_block(&mut self, frames: usize) {
                 debug_assert!(frames <= Self::MAX_BLOCK_SIZE);
 
@@ -900,6 +921,11 @@ impl<'a> CodegenContext<'a> {
                     // output assignments and stay readable after the block)
                     #(#event_input_clearing)*
                 }
+
+                // The loop consumed every staged event with frame_offset < frames,
+                // so anything left is beyond this block: re-queue it with the
+                // offset rebased so it fires sample-accurately in a later block.
+                #(#leftover_requeues)*
             }
         })
     }

--- a/oscen-lib/tests/block_processing_test.rs
+++ b/oscen-lib/tests/block_processing_test.rs
@@ -341,3 +341,67 @@ fn test_block_with_stream_input() {
         );
     }
 }
+
+// ============================================================================
+// Test 6: Events beyond the block are deferred, not dropped
+// ============================================================================
+
+#[test]
+fn test_event_beyond_block_is_deferred() {
+    use oscen::graph::{EventInstance, EventPayload};
+    use oscen::midi::RawMidiMessage;
+
+    let block_size = 32;
+    let event_frame = 40; // beyond the first block, 8 frames into the second
+
+    // Reference: per-sample processing with the event at the right sample
+    let note_on_bytes = [0x90, 81, 100];
+    let mut graph_a = EventBlockGraph::new();
+    graph_a.init(44100.0);
+    let mut per_sample_outputs = Vec::with_capacity(block_size * 2);
+    for i in 0..block_size * 2 {
+        if i == event_frame {
+            let msg = RawMidiMessage::new(&note_on_bytes);
+            let _ = graph_a.midi_in.try_push(EventInstance {
+                frame_offset: 0,
+                payload: EventPayload::Object(std::sync::Arc::new(msg)),
+            });
+        }
+        graph_a.process();
+        per_sample_outputs.push(graph_a.audio_out);
+    }
+
+    // Block: push the event with frame_offset beyond the first block, then
+    // process two blocks — the event must fire 8 frames into the second.
+    let msg = RawMidiMessage::new(&note_on_bytes);
+    let mut graph_b = EventBlockGraph::new();
+    graph_b.init(44100.0);
+    let _ = graph_b.midi_in.try_push(EventInstance {
+        frame_offset: event_frame as u32,
+        payload: EventPayload::Object(std::sync::Arc::new(msg)),
+    });
+
+    graph_b.process_block(block_size);
+    for i in 0..block_size {
+        assert_eq!(
+            graph_b.audio_out_block[i], per_sample_outputs[i],
+            "Deferred event fired early at sample {}: block={} per_sample={}",
+            i, graph_b.audio_out_block[i], per_sample_outputs[i]
+        );
+    }
+
+    graph_b.process_block(block_size);
+    for i in 0..block_size {
+        assert_eq!(
+            graph_b.audio_out_block[i],
+            per_sample_outputs[block_size + i],
+            "Deferred event mismatch at sample {}: block={} per_sample={}",
+            block_size + i,
+            graph_b.audio_out_block[i],
+            per_sample_outputs[block_size + i]
+        );
+    }
+
+    // The note actually arrived (frequency set to A5)
+    assert!((graph_b.voice_handler.frequency - 880.0).abs() < 0.01);
+}


### PR DESCRIPTION
Fixes issue surfaced during the examples work: generated process_block drained every queued event into local staging but only delivered those with frame_offset < frames — an event scheduled beyond the current block was silently discarded with the staging buffer. Any host pushing sample-accurate events that span a block boundary would lose them.

Leftover staged events are now re-queued after the block with their offsets rebased by the block length, so they fire sample-accurately in a later block. The loop structure guarantees everything remaining in staging has frame_offset >= frames, so the rebase cannot underflow. New events pushed by the host between blocks simply append and get sorted with the deferred ones at the next staging pass.

Regression test: an event at frame_offset 40 processed in two 32-frame blocks must match per-sample processing exactly — it fails on main (the note never fires; output stays at the default) and passes with the fix. The first version of this test used MIDI note 69, whose 440 Hz is exactly the voice handler's default frequency, making a dropped note undetectable — it now uses note 81 (880 Hz).

Full workspace suite: 76 test binaries, 0 failures; no new clippy warnings; fmt clean.